### PR TITLE
ASR: Add synced Libasr

### DIFF
--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -177,7 +177,7 @@ stmt
     | GoToTarget(int id)
     | If(expr test, stmt* body, stmt* orelse)
     | IfArithmetic(expr test, int lt_label, int eq_label, int gt_label)
-    | Print(expr? fmt, expr* values)
+    | Print(expr? fmt, expr* values, expr? separator, expr? end)
     | FileOpen(int label, expr? newunit, expr? filename, expr? status)
     | FileClose(int label, expr? unit, expr? iostat, expr? iomsg, expr? err, expr? status)
     | FileRead(int label, expr? unit, expr? fmt, expr? iomsg, expr? iostat, expr? id, expr* values)
@@ -190,7 +190,7 @@ stmt
               expr? read, expr? write, expr? readwrite, expr? delim,
               expr? pad, expr? flen, expr? blocksize, expr? convert,
               expr? carriagecontrol, expr? iolength)
-    | FileWrite(int label, expr? unit, expr? fmt, expr? iomsg, expr? iostat, expr? id, expr* values)
+    | FileWrite(int label, expr? unit, expr? fmt, expr? iomsg, expr? iostat, expr? id, expr* values, expr? separator, expr? end)
     | Return()
     | Select(expr test, case_stmt* body, stmt* default)
     | Stop(expr? code)
@@ -200,26 +200,22 @@ stmt
     | WhileLoop(expr test, stmt* body)
     | Nullify(symbol* vars)
     | Flush(int label, expr unit, expr? err, expr? iomsg, expr? iostat)
-    | ListAppend(symbol a, expr ele)
+    | ListAppend(expr a, expr ele)
     | AssociateBlockCall(symbol m)
     | CPtrToPointer(expr cptr, expr ptr, expr? shape)
-    | BlockCall(symbol m)
-    | SetInsert(symbol a, expr ele)
-    | SetRemove(symbol a, expr ele)
-    | ListInsert(symbol a, expr pos, expr ele)
-    | ListRemove(symbol a, expr ele)
-    | DictInsert(symbol a, expr key, expr value)
+    | BlockCall(int label, symbol m)
+    | SetInsert(expr a, expr ele)
+    | SetRemove(expr a, expr ele)
+    | ListInsert(expr a, expr pos, expr ele)
+    | ListRemove(expr a, expr ele)
+    | DictInsert(expr a, expr key, expr value)
 
 
 expr
-    = BoolOp(expr left, boolop op, expr right, ttype type, expr? value)
-    | BinOp(expr left, binop op, expr right, ttype type, expr? value, expr? overloaded)
-    | UnaryOp(unaryop op, expr operand, ttype type, expr? value)
+    = IfExp(expr test, expr body, expr orelse, ttype type, expr? value)
         -- Such as: (x, y+z), (3.0, 2.0) generally not known at compile time
     | ComplexConstructor(expr re, expr im, ttype type, expr? value)
     | NamedExpr(expr target, expr value, ttype type)
-    | Compare(expr left, cmpop op, expr right, ttype type, expr? value, expr? overloaded)
-    | IfExp(expr test, expr body, expr orelse, ttype type, expr? value)
     | FunctionCall(symbol name, symbol? original_name,
             call_arg* args, ttype type, expr? value, expr? dt)
     | DerivedTypeConstructor(symbol dt_sym, expr* args, ttype type, expr? value)
@@ -229,12 +225,20 @@ expr
     | IntegerBOZ(int v, integerboz intboz_type, ttype? type)
     | IntegerBitNot(expr arg, ttype type, expr? value)
     | IntegerUnaryMinus(expr arg, ttype type, expr? value)
+    | IntegerCompare(expr left, cmpop op, expr right, ttype type, expr? value)
+    | IntegerBinOp(expr left, binop op, expr right, ttype type, expr? value)
     | RealConstant(float r, ttype type)
     | RealUnaryMinus(expr arg, ttype type, expr? value)
+    | RealCompare(expr left, cmpop op, expr right, ttype type, expr? value)
+    | RealBinOp(expr left, binop op, expr right, ttype type, expr? value)
     | ComplexConstant(float re, float im, ttype type)
     | ComplexUnaryMinus(expr arg, ttype type, expr? value)
+    | ComplexCompare(expr left, cmpop op, expr right, ttype type, expr? value)
+    | ComplexBinOp(expr left, binop op, expr right, ttype type, expr? value)
     | LogicalConstant(bool value, ttype type)
     | LogicalNot(expr arg, ttype type, expr? value)
+    | LogicalCompare(expr left, cmpop op, expr right, ttype type, expr? value)
+    | LogicalBinOp(expr left, logicalbinop op, expr right, ttype type, expr? value)
 
     | ListConstant(expr* args, ttype type)
     | ListLen(expr arg, ttype type, expr? value)
@@ -254,6 +258,7 @@ expr
     | StringLen(expr arg, ttype type, expr? value)
     | StringItem(expr arg, expr idx, ttype type, expr? value)
     | StringSection(expr arg, expr start, expr end, expr step, ttype type, expr? value)
+    | StringCompare(expr left, cmpop op, expr right, ttype type, expr? value)
 
     | DictConstant(expr* keys, expr* values, ttype type)
     | DictLen(expr arg, ttype type, expr? value)
@@ -265,19 +270,23 @@ expr
     | ArrayTranspose(expr matrix, ttype type, expr? value)
     | ArrayMatMul(expr matrix_a, expr matrix_b, ttype type, expr? value)
     | ArrayPack(expr array, expr mask, expr? vector, ttype type, expr? value)
-    | Transfer(expr source, expr mold, expr? size, ttype type, expr? value)
+    | BitCast(expr source, expr mold, expr? size, ttype type, expr? value)
     | DerivedRef(expr v, symbol m, ttype type, expr? value)
+    | OverloadedCompare(expr left, cmpop op, expr right, ttype type, expr? value, expr overloaded)
+    | OverloadedBinOp(expr left, binop op, expr right, ttype type, expr? value, expr overloaded)
     | Cast(expr arg, cast_kind kind, ttype type, expr? value)
     | ComplexRe(expr arg, ttype type, expr? value)
     | ComplexIm(expr arg, ttype type, expr? value)
-    | DictItem(symbol a, expr key, expr? default, ttype type, expr? value)
+    | DictItem(expr a, expr key, expr? default, ttype type, expr? value)
     | CLoc(expr arg, ttype type, expr? value)
-    | ListItem(symbol a, expr pos, ttype type, expr? value)
-    | TupleItem(symbol a, expr pos, ttype type, expr? value)
+    | PointerToCPtr(expr arg, ttype type, expr? value)
+    | GetPointer(expr arg, ttype type, expr? value)
+    | ListItem(expr a, expr pos, ttype type, expr? value)
+    | TupleItem(expr a, expr pos, ttype type, expr? value)
     | ListSection(expr a, array_index section, ttype type, expr? value)
-    | ListPop(symbol a, expr? index, ttype type, expr? value)
-    | DictPop(symbol a, expr key, ttype type, expr? value)
-    | SetPop(symbol a, ttype type, expr? value)
+    | ListPop(expr a, expr? index, ttype type, expr? value)
+    | DictPop(expr a, expr key, ttype type, expr? value)
+    | SetPop(expr a, ttype type, expr? value)
 
 
 -- `len` in Character:
@@ -314,11 +323,9 @@ ttype
     | Pointer(ttype type)
     | CPtr()
 
-boolop = And | Or | Xor | NEqv | Eqv
+binop = Add | Sub | Mul | Div | Pow | BitAnd | BitOr | BitXor | BitLShift | BitRShift
 
-binop = Add | Sub | Mul | Div | Pow
-
-unaryop = Invert | Not | UAdd | USub
+logicalbinop = And | Or | Xor | NEqv | Eqv
 
 cmpop = Eq | NotEq | Lt | LtE | Gt | GtE
 
@@ -334,6 +341,9 @@ cast_kind
     | RealToComplex
     | IntegerToComplex
     | IntegerToLogical
+    | RealToLogical
+    | CharacterToLogical
+    | ComplexToLogical
     | ComplexToComplex
     | ComplexToReal
     | LogicalToInteger

--- a/src/libasr/CMakeLists.txt
+++ b/src/libasr/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SRC
     pass/flip_sign.cpp
     pass/div_to_mul.cpp
     pass/fma.cpp
+    pass/loop_vectorise.cpp
     pass/sign_from_value.cpp
     pass/inline_function_calls.cpp
     pass/loop_unroll.cpp

--- a/src/libasr/asr_scopes.h
+++ b/src/libasr/asr_scopes.h
@@ -47,7 +47,7 @@ struct SymbolTable {
         return scope[name];
     }
 
-    const std::map<std::string, ASR::symbol_t*>& get_scope() {
+    const std::map<std::string, ASR::symbol_t*>& get_scope() const {
         return scope;
     }
 

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -242,9 +242,10 @@ ASR::asr_t* getDerivedRef_t(Allocator& al, const Location& loc,
     ASR::ttype_t* member_type = member_variable->m_type;
     switch( member_type->type ) {
         case ASR::ttypeType::Derived: {
-            ASR::Derived_t* der = (ASR::Derived_t*)(&(member_type->base));
-            ASR::DerivedType_t* der_type = (ASR::DerivedType_t*)(&(der->m_derived_type->base));
-            if( der_type->m_symtab->counter != current_scope->counter ) {
+            // Sync: Probably failing at the following two lines
+            ASR::Derived_t* der = ASR::down_cast<ASR::Derived_t>(member_type);
+            ASR::DerivedType_t* der_type = ASR::down_cast<ASR::DerivedType_t>(der->m_derived_type);
+            if( current_scope->resolve_symbol(std::string(der_type->m_name)) == nullptr ) {
                 ASR::symbol_t* der_ext;
                 char* module_name = (char*)"~nullptr";
                 ASR::symbol_t* m_external = der->m_derived_type;
@@ -387,6 +388,9 @@ bool is_op_overloaded(ASR::binopType op, std::string& intrinsic_op_name,
                 result = false;
             }
             break;
+        }
+        default: {
+            throw LFortranException("Binary operator '" + ASRUtils::binop_to_str_python(op) + "' not supported yet");
         }
     }
     if( result && curr_scope->get_symbol(intrinsic_op_name) == nullptr ) {
@@ -875,6 +879,9 @@ ASR::asr_t* make_Cast_t_value(Allocator &al, const Location &a_loc,
 
     return ASR::make_Cast_t(al, a_loc, a_arg, a_kind, a_type, value);
 }
+
+//Initialize pointer to zero so that it can be initialized in first call to get_instance
+ASRUtils::LabelGenerator* ASRUtils::LabelGenerator::label_generator = nullptr;
 
 } // namespace ASRUtils
 

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -609,7 +609,7 @@ static inline std::string type_python_1dim_helper(const std::string & res,
     }
 
     if( ASRUtils::expr_value(e->m_end) ) {
-        int64_t end_dim;
+        int64_t end_dim = -1;
         ASRUtils::extract_value(ASRUtils::expr_value(e->m_end), end_dim);
         return res + "[" + std::to_string(end_dim + 1) + "]";
     }
@@ -1047,163 +1047,163 @@ inline bool is_same_type_pointer(ASR::ttype_t* source, ASR::ttype_t* dest) {
     return res;
 }
 
-            inline int extract_kind_str(char* m_n, char *&kind_str) {
-                char *p = m_n;
-                while (*p != '\0') {
-                    if (*p == '_') {
-                        p++;
-                        std::string kind = std::string(p);
-                        int ikind = std::atoi(p);
-                        if (ikind == 0) {
-                            // Not an integer, return a string
-                            kind_str = p;
-                            return 0;
-                        } else {
-                            return ikind;
-                        }
-                    }
-                    if (*p == 'd' || *p == 'D') {
-                        // Double precision
-                        return 8;
-                    }
-                    p++;
-                }
-                return 4;
+inline int extract_kind_str(char* m_n, char *&kind_str) {
+    char *p = m_n;
+    while (*p != '\0') {
+        if (*p == '_') {
+            p++;
+            std::string kind = std::string(p);
+            int ikind = std::atoi(p);
+            if (ikind == 0) {
+                // Not an integer, return a string
+                kind_str = p;
+                return 0;
+            } else {
+                return ikind;
             }
+        }
+        if (*p == 'd' || *p == 'D') {
+            // Double precision
+            return 8;
+        }
+        p++;
+    }
+    return 4;
+}
 
-            template <typename SemanticError>
-            inline int extract_kind(ASR::expr_t* kind_expr, const Location& loc) {
-                int a_kind = 4;
-                switch( kind_expr->type ) {
-                    case ASR::exprType::IntegerConstant: {
-                        a_kind = ASR::down_cast<ASR::IntegerConstant_t>
-                                (kind_expr)->m_n;
-                        break;
-                    }
-                    case ASR::exprType::Var: {
-                        ASR::Var_t* kind_var =
-                            ASR::down_cast<ASR::Var_t>(kind_expr);
-                        ASR::Variable_t* kind_variable =
-                            ASR::down_cast<ASR::Variable_t>(
-                                symbol_get_past_external(kind_var->m_v));
-                        if( kind_variable->m_storage == ASR::storage_typeType::Parameter ) {
-                            if( kind_variable->m_type->type == ASR::ttypeType::Integer ) {
-                                LFORTRAN_ASSERT( kind_variable->m_value != nullptr );
-                                a_kind = ASR::down_cast<ASR::IntegerConstant_t>(kind_variable->m_value)->m_n;
-                            } else {
-                                std::string msg = "Integer variable required. " + std::string(kind_variable->m_name) +
-                                                " is not an Integer variable.";
-                                throw SemanticError(msg, loc);
-                            }
-                        } else {
-                            std::string msg = "Parameter " + std::string(kind_variable->m_name) +
-                                            " is a variable, which does not reduce to a constant expression";
-                            throw SemanticError(msg, loc);
-                        }
-                        break;
-                    }
-                    default: {
-                        throw SemanticError(R"""(Only Integer literals or expressions which reduce to constant Integer are accepted as kind parameters.)""",
-                                            loc);
-                    }
+template <typename SemanticError>
+inline int extract_kind(ASR::expr_t* kind_expr, const Location& loc) {
+    int a_kind = 4;
+    switch( kind_expr->type ) {
+        case ASR::exprType::IntegerConstant: {
+            a_kind = ASR::down_cast<ASR::IntegerConstant_t>
+                    (kind_expr)->m_n;
+            break;
+        }
+        case ASR::exprType::Var: {
+            ASR::Var_t* kind_var =
+                ASR::down_cast<ASR::Var_t>(kind_expr);
+            ASR::Variable_t* kind_variable =
+                ASR::down_cast<ASR::Variable_t>(
+                    symbol_get_past_external(kind_var->m_v));
+            if( kind_variable->m_storage == ASR::storage_typeType::Parameter ) {
+                if( kind_variable->m_type->type == ASR::ttypeType::Integer ) {
+                    LFORTRAN_ASSERT( kind_variable->m_value != nullptr );
+                    a_kind = ASR::down_cast<ASR::IntegerConstant_t>(kind_variable->m_value)->m_n;
+                } else {
+                    std::string msg = "Integer variable required. " + std::string(kind_variable->m_name) +
+                                    " is not an Integer variable.";
+                    throw SemanticError(msg, loc);
                 }
-                return a_kind;
+            } else {
+                std::string msg = "Parameter " + std::string(kind_variable->m_name) +
+                                " is a variable, which does not reduce to a constant expression";
+                throw SemanticError(msg, loc);
             }
+            break;
+        }
+        default: {
+            throw SemanticError(R"""(Only Integer literals or expressions which reduce to constant Integer are accepted as kind parameters.)""",
+                                loc);
+        }
+    }
+    return a_kind;
+}
 
-            template <typename SemanticError>
-            inline int extract_len(ASR::expr_t* len_expr, const Location& loc) {
-                int a_len = -10;
-                switch( len_expr->type ) {
-                    case ASR::exprType::IntegerConstant: {
-                        a_len = ASR::down_cast<ASR::IntegerConstant_t>
-                                (len_expr)->m_n;
-                        break;
-                    }
-                    case ASR::exprType::Var: {
-                        ASR::Var_t* len_var =
-                            ASR::down_cast<ASR::Var_t>(len_expr);
-                        ASR::Variable_t* len_variable =
-                            ASR::down_cast<ASR::Variable_t>(
-                                symbol_get_past_external(len_var->m_v));
-                        if( len_variable->m_storage == ASR::storage_typeType::Parameter ) {
-                            if( len_variable->m_type->type == ASR::ttypeType::Integer ) {
-                                LFORTRAN_ASSERT( len_variable->m_value != nullptr );
-                                a_len = ASR::down_cast<ASR::IntegerConstant_t>(len_variable->m_value)->m_n;
-                            } else {
-                                std::string msg = "Integer variable required. " + std::string(len_variable->m_name) +
-                                                " is not an Integer variable.";
-                                throw SemanticError(msg, loc);
-                            }
-                        } else {
-                            // An expression is beind used for `len` that cannot be evaluated
-                            a_len = -3;
-                        }
-                        break;
-                    }
-                    case ASR::exprType::FunctionCall: {
-                        a_len = -3;
-                        break;
-                    }
-                    case ASR::exprType::IntegerBinOp: {
-                        a_len = -3;
-                        break;
-                    }
-                    default: {
-                        throw SemanticError("Only Integers or variables implemented so far for `len` expressions",
-                                            loc);
-                    }
+template <typename SemanticError>
+inline int extract_len(ASR::expr_t* len_expr, const Location& loc) {
+    int a_len = -10;
+    switch( len_expr->type ) {
+        case ASR::exprType::IntegerConstant: {
+            a_len = ASR::down_cast<ASR::IntegerConstant_t>
+                    (len_expr)->m_n;
+            break;
+        }
+        case ASR::exprType::Var: {
+            ASR::Var_t* len_var =
+                ASR::down_cast<ASR::Var_t>(len_expr);
+            ASR::Variable_t* len_variable =
+                ASR::down_cast<ASR::Variable_t>(
+                    symbol_get_past_external(len_var->m_v));
+            if( len_variable->m_storage == ASR::storage_typeType::Parameter ) {
+                if( len_variable->m_type->type == ASR::ttypeType::Integer ) {
+                    LFORTRAN_ASSERT( len_variable->m_value != nullptr );
+                    a_len = ASR::down_cast<ASR::IntegerConstant_t>(len_variable->m_value)->m_n;
+                } else {
+                    std::string msg = "Integer variable required. " + std::string(len_variable->m_name) +
+                                    " is not an Integer variable.";
+                    throw SemanticError(msg, loc);
                 }
-                LFORTRAN_ASSERT(a_len != -10)
-                return a_len;
+            } else {
+                // An expression is beind used for `len` that cannot be evaluated
+                a_len = -3;
             }
+            break;
+        }
+        case ASR::exprType::FunctionCall: {
+            a_len = -3;
+            break;
+        }
+        case ASR::exprType::IntegerBinOp: {
+            a_len = -3;
+            break;
+        }
+        default: {
+            throw SemanticError("Only Integers or variables implemented so far for `len` expressions",
+                                loc);
+        }
+    }
+    LFORTRAN_ASSERT(a_len != -10)
+    return a_len;
+}
 
-            inline bool check_equal_type(ASR::ttype_t* x, ASR::ttype_t* y) {
-                if( ASR::is_a<ASR::Pointer_t>(*x) ||
-                    ASR::is_a<ASR::Pointer_t>(*y) ) {
-                    x = ASRUtils::type_get_past_pointer(x);
-                    y = ASRUtils::type_get_past_pointer(y);
-                    return check_equal_type(x, y);
-                } else if (ASR::is_a<ASR::List_t>(*x) && ASR::is_a<ASR::List_t>(*y)) {
-                    x = ASR::down_cast<ASR::List_t>(x)->m_type;
-                    y = ASR::down_cast<ASR::List_t>(y)->m_type;
-                    return check_equal_type(x, y);
-                } else if (ASR::is_a<ASR::Set_t>(*x) && ASR::is_a<ASR::Set_t>(*y)) {
-                    x = ASR::down_cast<ASR::Set_t>(x)->m_type;
-                    y = ASR::down_cast<ASR::Set_t>(y)->m_type;
-                    return check_equal_type(x, y);
-                } else if (ASR::is_a<ASR::Dict_t>(*x) && ASR::is_a<ASR::Dict_t>(*y)) {
-                    ASR::ttype_t *x_key_type = ASR::down_cast<ASR::Dict_t>(x)->m_key_type;
-                    ASR::ttype_t *y_key_type = ASR::down_cast<ASR::Dict_t>(y)->m_key_type;
-                    ASR::ttype_t *x_value_type = ASR::down_cast<ASR::Dict_t>(x)->m_value_type;
-                    ASR::ttype_t *y_value_type = ASR::down_cast<ASR::Dict_t>(y)->m_value_type;
-                    return (check_equal_type(x_key_type, y_key_type) &&
-                            check_equal_type(x_value_type, y_value_type));
-                } else if (ASR::is_a<ASR::Tuple_t>(*x) && ASR::is_a<ASR::Tuple_t>(*y)) {
-                    ASR::Tuple_t *a = ASR::down_cast<ASR::Tuple_t>(x);
-                    ASR::Tuple_t *b = ASR::down_cast<ASR::Tuple_t>(y);
-                    if(a->n_type != b->n_type) {
-                        return false;
-                    }
-                    bool result = true;
-                    for (size_t i=0; i<a->n_type; i++) {
-                        result = result && check_equal_type(a->m_type[i], b->m_type[i]);
-                        if (!result) {
-                            return false;
-                        }
-                    }
-                    return result;
-                }
-
-                int64_t x_kind = ASRUtils::extract_kind_from_ttype_t(x);
-                int64_t y_kind = ASRUtils::extract_kind_from_ttype_t(y);
-
-                if( x->type == y->type &&
-                    x_kind == y_kind ) {
-                    return true;
-                }
-
+inline bool check_equal_type(ASR::ttype_t* x, ASR::ttype_t* y) {
+    if( ASR::is_a<ASR::Pointer_t>(*x) ||
+        ASR::is_a<ASR::Pointer_t>(*y) ) {
+        x = ASRUtils::type_get_past_pointer(x);
+        y = ASRUtils::type_get_past_pointer(y);
+        return check_equal_type(x, y);
+    } else if (ASR::is_a<ASR::List_t>(*x) && ASR::is_a<ASR::List_t>(*y)) {
+        x = ASR::down_cast<ASR::List_t>(x)->m_type;
+        y = ASR::down_cast<ASR::List_t>(y)->m_type;
+        return check_equal_type(x, y);
+    } else if (ASR::is_a<ASR::Set_t>(*x) && ASR::is_a<ASR::Set_t>(*y)) {
+        x = ASR::down_cast<ASR::Set_t>(x)->m_type;
+        y = ASR::down_cast<ASR::Set_t>(y)->m_type;
+        return check_equal_type(x, y);
+    } else if (ASR::is_a<ASR::Dict_t>(*x) && ASR::is_a<ASR::Dict_t>(*y)) {
+        ASR::ttype_t *x_key_type = ASR::down_cast<ASR::Dict_t>(x)->m_key_type;
+        ASR::ttype_t *y_key_type = ASR::down_cast<ASR::Dict_t>(y)->m_key_type;
+        ASR::ttype_t *x_value_type = ASR::down_cast<ASR::Dict_t>(x)->m_value_type;
+        ASR::ttype_t *y_value_type = ASR::down_cast<ASR::Dict_t>(y)->m_value_type;
+        return (check_equal_type(x_key_type, y_key_type) &&
+                check_equal_type(x_value_type, y_value_type));
+    } else if (ASR::is_a<ASR::Tuple_t>(*x) && ASR::is_a<ASR::Tuple_t>(*y)) {
+        ASR::Tuple_t *a = ASR::down_cast<ASR::Tuple_t>(x);
+        ASR::Tuple_t *b = ASR::down_cast<ASR::Tuple_t>(y);
+        if(a->n_type != b->n_type) {
+            return false;
+        }
+        bool result = true;
+        for (size_t i=0; i<a->n_type; i++) {
+            result = result && check_equal_type(a->m_type[i], b->m_type[i]);
+            if (!result) {
                 return false;
             }
+        }
+        return result;
+    }
+
+    int64_t x_kind = ASRUtils::extract_kind_from_ttype_t(x);
+    int64_t y_kind = ASRUtils::extract_kind_from_ttype_t(y);
+
+    if( x->type == y->type &&
+        x_kind == y_kind ) {
+        return true;
+    }
+
+    return false;
+}
 
 int select_generic_procedure(const Vec<ASR::call_arg_t> &args,
         const ASR::GenericProcedure_t &p, Location loc,

--- a/src/libasr/codegen/asr_to_c.cpp
+++ b/src/libasr/codegen/asr_to_c.cpp
@@ -9,6 +9,7 @@
 #include <libasr/asr_utils.h>
 #include <libasr/string_utils.h>
 #include <libasr/pass/unused_functions.h>
+#include <libasr/pass/class_constructor.h>
 
 
 namespace LFortran {
@@ -44,12 +45,17 @@ std::string format_type_c(const std::string &dims, const std::string &type,
         const std::string &name, bool use_ref, bool /*dummy*/)
 {
     std::string fmt;
-    if (dims.size() == 0) {
-        std::string ref;
-        if (use_ref) ref = "&";
-        fmt = type + " " + ref + name;
+    // Sync: Not sure of the following code
+    // std::string ref = "", ptr = "";
+    // if (dims.size() > 0) ptr = "*";
+    // if (use_ref) ref = "&";
+    // fmt = type + " " + ptr + ref + name;
+    std::string ref = "";
+    if (use_ref) ref = "&";
+    if( dims == "*" ) {
+        fmt = type + " " + dims + ref + name;
     } else {
-        throw CodeGenError("Dimensions is not supported yet.");
+        fmt = type + " " + ref + name + dims;
     }
     return fmt;
 }
@@ -58,10 +64,41 @@ class ASRToCVisitor : public BaseCCPPVisitor<ASRToCVisitor>
 {
 public:
 
-    ASRToCVisitor(diag::Diagnostics &diag) : BaseCCPPVisitor(diag,
-        false, false, true) {}
+    ASRToCVisitor(diag::Diagnostics &diag, Platform &platform)
+         : BaseCCPPVisitor(diag, platform, false, false, true) {}
 
-    std::string convert_variable_decl(const ASR::Variable_t &v)
+    std::string convert_dims_c(size_t n_dims, ASR::dimension_t *m_dims)
+    {
+        std::string dims;
+        for (size_t i=0; i<n_dims; i++) {
+            ASR::expr_t *start = m_dims[i].m_start;
+            ASR::expr_t *end = m_dims[i].m_end;
+            if (!start && !end) {
+                dims += "*";
+            } else if (start && end) {
+                ASR::expr_t* start_value = ASRUtils::expr_value(start);
+                ASR::expr_t* end_value = ASRUtils::expr_value(end);
+                if( start_value && end_value ) {
+                    int64_t start_int = -1, end_int = -1;
+                    ASRUtils::extract_value(start_value, start_int);
+                    ASRUtils::extract_value(end_value, end_int);
+                    dims += "[" + std::to_string(end_int - start_int + 1) + "]";
+                } else {
+                    this->visit_expr(*start);
+                    std::string start_expr = std::move(src);
+                    this->visit_expr(*end);
+                    std::string end_expr = std::move(src);
+                    dims += "[" + end_expr + " - " + start_expr + " + 1]";
+                }
+            } else {
+                throw CodeGenError("Dimension type not supported");
+            }
+        }
+        return dims;
+    }
+
+    std::string convert_variable_decl(const ASR::Variable_t &v,
+                                      bool pre_initialise_derived_type=true, bool use_static=true)
     {
         std::string sub;
         bool use_ref = (v.m_intent == LFortran::ASRUtils::intent_out || v.m_intent == LFortran::ASRUtils::intent_inout);
@@ -71,7 +108,17 @@ public:
             if (ASRUtils::is_integer(*t2)) {
                 ASR::Integer_t *t = ASR::down_cast<ASR::Integer_t>(t2);
                 std::string dims = convert_dims_c(t->n_dims, t->m_dims);
-                sub = format_type_c(dims, "int *", v.m_name, use_ref, dummy);
+                std::string type_name = "int" + std::to_string(t->m_kind * 8) + "_t";
+                if( !ASRUtils::is_array(v.m_type) ) {
+                    type_name.append(" *");
+                }
+                sub = format_type_c(dims, type_name, v.m_name, use_ref, dummy);
+            } else if(ASR::is_a<ASR::Derived_t>(*t2)) {
+                ASR::Derived_t *t = ASR::down_cast<ASR::Derived_t>(t2);
+                std::string der_type_name = ASRUtils::symbol_name(t->m_derived_type);
+                std::string dims = convert_dims_c(t->n_dims, t->m_dims);
+                sub = format_type_c(dims, "struct " + der_type_name + "*",
+                                    v.m_name, use_ref, dummy);
             } else {
                 diag.codegen_error_label("Type number '"
                     + std::to_string(v.m_type->type)
@@ -79,9 +126,11 @@ public:
                 throw Abort();
             }
         } else {
+            std::string dims;
             if (ASRUtils::is_integer(*v.m_type)) {
+                headers.insert("inttypes");
                 ASR::Integer_t *t = ASR::down_cast<ASR::Integer_t>(v.m_type);
-                std::string dims = convert_dims_c(t->n_dims, t->m_dims);
+                dims = convert_dims_c(t->n_dims, t->m_dims);
                 std::string type_name;
                 if (t->m_kind == 1) {
                     type_name = "int8_t";
@@ -95,36 +144,62 @@ public:
                 sub = format_type_c(dims, type_name, v.m_name, use_ref, dummy);
             } else if (ASRUtils::is_real(*v.m_type)) {
                 ASR::Real_t *t = ASR::down_cast<ASR::Real_t>(v.m_type);
-                std::string dims = convert_dims_c(t->n_dims, t->m_dims);
+                dims = convert_dims_c(t->n_dims, t->m_dims);
                 std::string type_name = "float";
                 if (t->m_kind == 8) type_name = "double";
                 sub = format_type_c(dims, type_name, v.m_name, use_ref, dummy);
             } else if (ASRUtils::is_complex(*v.m_type)) {
+                headers.insert("complex");
                 ASR::Complex_t *t = ASR::down_cast<ASR::Complex_t>(v.m_type);
-                std::string dims = convert_dims_c(t->n_dims, t->m_dims);
+                dims = convert_dims_c(t->n_dims, t->m_dims);
                 std::string type_name = "float complex";
                 if (t->m_kind == 8) type_name = "double complex";
                 sub = format_type_c(dims, type_name, v.m_name, use_ref, dummy);
             } else if (ASRUtils::is_logical(*v.m_type)) {
                 ASR::Logical_t *t = ASR::down_cast<ASR::Logical_t>(v.m_type);
+                dims = convert_dims_c(t->n_dims, t->m_dims);
+                sub = format_type_c(dims, "bool", v.m_name, use_ref, dummy);
+            }else if (ASRUtils::is_character(*v.m_type)) {
+                ASR::Character_t *t = ASR::down_cast<ASR::Character_t>(v.m_type);
                 std::string dims = convert_dims_c(t->n_dims, t->m_dims);
-                sub = format_type_c(dims, "int8_t", v.m_name, use_ref, dummy);
-            } else if (ASRUtils::is_character(*v.m_type)) {
-                // TODO
+                sub = format_type_c(dims, "char *", v.m_name, use_ref, dummy);
             } else if (ASR::is_a<ASR::Derived_t>(*v.m_type)) {
+                std::string indent(indentation_level*indentation_spaces, ' ');
                 ASR::Derived_t *t = ASR::down_cast<ASR::Derived_t>(v.m_type);
+                std::string der_type_name = ASRUtils::symbol_name(t->m_derived_type);
                 std::string dims = convert_dims_c(t->n_dims, t->m_dims);
-                sub = format_type_c(dims, "struct", v.m_name, use_ref, dummy);
-                if (v.m_symbolic_value) {
-                    this->visit_expr(*v.m_symbolic_value);
-                    std::string init = src;
-                    sub += "=" + init;
+                if( v.m_intent == ASRUtils::intent_local && pre_initialise_derived_type ) {
+                    std::string value_var_name = v.m_parent_symtab->get_unique_name(std::string(v.m_name) + "_value");
+                    sub = format_type_c(dims, "struct " + der_type_name,
+                                        value_var_name, use_ref, dummy);
+                    if (v.m_symbolic_value) {
+                        this->visit_expr(*v.m_symbolic_value);
+                        std::string init = src;
+                        sub += "=" + init;
+                    }
+                    sub += ";\n";
+                    sub += indent + format_type_c("", "struct " + der_type_name + "*", v.m_name, use_ref, dummy);
+                    sub += "= &" + value_var_name;
+                    return sub;
+                } else {
+                    sub = format_type_c(dims, "struct " + der_type_name + "*",
+                                        v.m_name, use_ref, dummy);
                 }
+            } else if (ASR::is_a<ASR::CPtr_t>(*v.m_type)) {
+                sub = format_type_c("", "void*", v.m_name, false, false);
             } else {
                 diag.codegen_error_label("Type number '"
                     + std::to_string(v.m_type->type)
                     + "' not supported", {v.base.base.loc}, "");
                 throw Abort();
+            }
+            if (dims.size() == 0 && v.m_storage == ASR::storage_typeType::Save && use_static) {
+                sub = "static " + sub;
+            }
+            if (dims.size() == 0 && v.m_symbolic_value) {
+                this->visit_expr(*v.m_symbolic_value);
+                std::string init = src;
+                sub += "=" + init;
             }
         }
         return sub;
@@ -132,6 +207,7 @@ public:
 
 
     void visit_TranslationUnit(const ASR::TranslationUnit_t &x) {
+        global_scope = x.m_global_scope;
         // All loose statements must be converted to a function, so the items
         // must be empty:
         LFORTRAN_ASSERT(x.n_items == 0);
@@ -139,21 +215,75 @@ public:
         indentation_level = 0;
         indentation_spaces = 4;
 
-        std::string headers =
-R"(#include <assert.h>
-#include <complex.h>
-#include <inttypes.h>
+        std::string head =
+R"(
+#include <stdlib.h>
+#include <stdbool.h>
 #include <stdio.h>
-#include <math.h>
-
 #include <lfortran_intrinsics.h>
 
+#define ASSERT(cond)                                                           \
+    {                                                                          \
+        if (!(cond)) {                                                         \
+            printf("%s%s", "ASSERT failed: ", __FILE__);                       \
+            printf("%s%s", "\nfunction ", __func__);                           \
+            printf("%s%d%s", "(), line number ", __LINE__, " at \n");          \
+            printf("%s%s", #cond, "\n");                                       \
+            exit(1);                                                           \
+        }                                                                      \
+    }
+#define ASSERT_MSG(cond, msg)                                                  \
+    {                                                                          \
+        if (!(cond)) {                                                         \
+            printf("%s%s", "ASSERT failed: ", __FILE__);                       \
+            printf("%s%s", "\nfunction ", __func__);                           \
+            printf("%s%d%s", "(), line number ", __LINE__, " at \n");          \
+            printf("%s%s", #cond, "\n");                                       \
+            printf("%s", "ERROR MESSAGE:\n");                                  \
+            printf("%s%s", msg, "\n");                                         \
+            exit(1);                                                           \
+        }                                                                      \
+    }
+
 )";
-        unit_src += headers;
+        unit_src += head;
 
+        for (auto &item : x.m_global_scope->get_scope()) {
+            if (ASR::is_a<ASR::DerivedType_t>(*item.second)) {
+                unit_src += "struct " + item.first + ";\n\n";
+            }
+        }
 
-        // TODO: We need to pre-declare all functions first, then generate code
+        for (auto &item : x.m_global_scope->get_scope()) {
+            if (ASR::is_a<ASR::Variable_t>(*item.second)) {
+                ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(item.second);
+                unit_src += convert_variable_decl(*v) + ";\n";
+            }
+        }
+
+        for (auto &item : x.m_global_scope->get_scope()) {
+            if (ASR::is_a<ASR::DerivedType_t>(*item.second)) {
+                visit_symbol(*item.second);
+                unit_src += src;
+            }
+        }
+
+        // Pre-declare all functions first, then generate code
         // Otherwise some function might not be found.
+        unit_src += "// Forward declarations\n";
+        unit_src += declare_all_functions(*x.m_global_scope);
+        // Now pre-declare all functions from modules and programs
+        for (auto &item : x.m_global_scope->get_scope()) {
+            if (ASR::is_a<ASR::Module_t>(*item.second)) {
+                ASR::Module_t *m = ASR::down_cast<ASR::Module_t>(item.second);
+                unit_src += declare_all_functions(*m->m_symtab);
+            } else if (ASR::is_a<ASR::Program_t>(*item.second)) {
+                ASR::Program_t *p = ASR::down_cast<ASR::Program_t>(item.second);
+                unit_src += declare_all_functions(*p->m_symtab);
+            }
+        }
+        unit_src += "\n";
+        unit_src += "// Implementations\n";
 
         {
             // Process intrinsic modules in the right order
@@ -164,8 +294,10 @@ R"(#include <assert.h>
                     != x.m_global_scope->get_scope().end());
                 if (startswith(item, "lfortran_intrinsic")) {
                     ASR::symbol_t *mod = x.m_global_scope->get_symbol(item);
-                    visit_symbol(*mod);
-                    unit_src += src;
+                    if( ASRUtils::get_body_size(mod) != 0 ) {
+                        visit_symbol(*mod);
+                        unit_src += src;
+                    }
                 }
             }
         }
@@ -174,8 +306,10 @@ R"(#include <assert.h>
         for (auto &item : x.m_global_scope->get_scope()) {
             if (ASR::is_a<ASR::Function_t>(*item.second)
                 || ASR::is_a<ASR::Subroutine_t>(*item.second)) {
-                visit_symbol(*item.second);
-                unit_src += src;
+                if( ASRUtils::get_body_size(item.second) != 0 ) {
+                    visit_symbol(*item.second);
+                    unit_src += src;
+                }
             }
         }
 
@@ -199,8 +333,11 @@ R"(#include <assert.h>
                 unit_src += src;
             }
         }
-
-        src = unit_src;
+        std::string to_include = "";
+        for (auto s: headers) {
+            to_include += "#include <" + s + ".h>\n";
+        }
+        src = to_include + unit_src;
     }
 
     void visit_Program(const ASR::Program_t &x) {
@@ -243,6 +380,22 @@ R"(#include <assert.h>
         indentation_level -= 2;
     }
 
+    void visit_DerivedType(const ASR::DerivedType_t& x) {
+        std::string indent(indentation_level*indentation_spaces, ' ');
+        indentation_level += 1;
+        std::string open_struct = indent + "struct " + std::string(x.m_name) + " {\n";
+        std::string body = "";
+        indent.push_back(' ');
+        for( size_t i = 0; i < x.n_members; i++ ) {
+            ASR::symbol_t* member = x.m_symtab->get_symbol(x.m_members[i]);
+            LFORTRAN_ASSERT(ASR::is_a<ASR::Variable_t>(*member));
+            body += indent + convert_variable_decl(*ASR::down_cast<ASR::Variable_t>(member), false) + ";\n";
+        }
+        indentation_level -= 1;
+        std::string end_struct = "};\n\n";
+        src = open_struct + body + end_struct;
+    }
+
     void visit_LogicalConstant(const ASR::LogicalConstant_t &x) {
         if (x.m_value == true) {
             src = "true";
@@ -252,44 +405,24 @@ R"(#include <assert.h>
         last_expr_precedence = 2;
     }
 
-    void visit_Cast(const ASR::Cast_t &x) {
-        visit_expr(*x.m_arg);
-        switch (x.m_kind) {
-            case (ASR::cast_kindType::IntegerToReal) : {
-                src = "(float)(" + src + ")";
-                break;
-            }
-            case (ASR::cast_kindType::RealToInteger) : {
-                src = "(int)(" + src + ")";
-                break;
-            }
-            case (ASR::cast_kindType::RealToReal) : {
-                // In C++, we do not need to cast float to float explicitly:
-                // src = src;
-                break;
-            }
-            case (ASR::cast_kindType::IntegerToInteger) : {
-                // In C++, we do not need to cast int <-> long long explicitly:
-                // src = src;
-                break;
-            }
-            case (ASR::cast_kindType::ComplexToComplex) : {
-                break;
-            }
-            case (ASR::cast_kindType::ComplexToReal) : {
-                src = "creal(" + src + ")";
-                break;
-            }
-            case (ASR::cast_kindType::LogicalToInteger) : {
-                src = "(int)(" + src + ")";
-                break;
-            }
-            default : throw CodeGenError("Cast kind " + std::to_string(x.m_kind) + " not implemented");
+    void visit_Assert(const ASR::Assert_t &x) {
+        std::string indent(indentation_level*indentation_spaces, ' ');
+        std::string out = indent;
+        if (x.m_msg) {
+            out += "ASSERT_MSG(";
+            visit_expr(*x.m_test);
+            out += src + ", ";
+            visit_expr(*x.m_msg);
+            out += src + ");\n";
+        } else {
+            out += "ASSERT(";
+            visit_expr(*x.m_test);
+            out += src + ");\n";
         }
-        last_expr_precedence = 2;
+        src = out;
     }
 
-    std::string get_print_type(ASR::ttype_t *t) {
+    std::string get_print_type(ASR::ttype_t *t, bool deref_ptr) {
         switch (t->type) {
             case ASR::ttypeType::Integer: {
                 ASR::Integer_t *i = (ASR::Integer_t*)t;
@@ -297,7 +430,13 @@ R"(#include <assert.h>
                     case 1: { return "%d"; }
                     case 2: { return "%d"; }
                     case 4: { return "%d"; }
-                    case 8: { return "%lli"; }
+                    case 8: {
+                        if (platform == Platform::Linux) {
+                            return "%li";
+                        } else {
+                            return "%lli";
+                        }
+                    }
                     default: { throw LFortranException("Integer kind not supported"); }
                 }
             }
@@ -315,6 +454,17 @@ R"(#include <assert.h>
             case ASR::ttypeType::Character: {
                 return "%s";
             }
+            case ASR::ttypeType::CPtr: {
+                return "%p";
+            }
+            case ASR::ttypeType::Pointer: {
+                if( !deref_ptr ) {
+                    return "%p";
+                } else {
+                    ASR::Pointer_t* type_ptr = ASR::down_cast<ASR::Pointer_t>(t);
+                    return get_print_type(type_ptr->m_type, false);
+                }
+            }
             default : throw LFortranException("Not implemented");
         }
     }
@@ -323,13 +473,22 @@ R"(#include <assert.h>
         std::string indent(indentation_level*indentation_spaces, ' ');
         std::string out = indent + "printf(\"";
         std::vector<std::string> v;
+        std::string separator;
+        if (x.m_separator) {
+            this->visit_expr(*x.m_separator);
+            separator = src;
+        } else {
+            separator = "\" \"";
+        }
         for (size_t i=0; i<x.n_values; i++) {
             this->visit_expr(*x.m_values[i]);
-            out += get_print_type(ASRUtils::expr_type(x.m_values[i]));
-            if (i+1!=x.n_values) {
-                out += " ";
-            }
+            ASR::ttype_t* value_type = ASRUtils::expr_type(x.m_values[i]);
+            out += get_print_type(value_type, ASR::is_a<ASR::ArrayRef_t>(*x.m_values[i]));
             v.push_back(src);
+            if (i+1!=x.n_values) {
+                out += "\%s";
+                v.push_back(separator);
+            }
         }
         out += "\\n\"";
         if (!v.empty()) {
@@ -341,19 +500,14 @@ R"(#include <assert.h>
         src = out;
     }
 
-    void visit_ErrorStop(const ASR::ErrorStop_t & /* x */) {
-        std::string indent(indentation_level*indentation_spaces, ' ');
-        src = indent + "fprintf(stderr, \"ERROR STOP\");\n";
-        src += indent + "exit(1);\n";
-    }
-
 };
 
 Result<std::string> asr_to_c(Allocator &al, ASR::TranslationUnit_t &asr,
-    diag::Diagnostics &diagnostics)
+    diag::Diagnostics &diagnostics, Platform &platform)
 {
-    pass_unused_functions(al, asr);
-    ASRToCVisitor v(diagnostics);
+    pass_unused_functions(al, asr, true);
+    pass_replace_class_constructor(al, asr);
+    ASRToCVisitor v(diagnostics, platform);
     try {
         v.visit_asr((ASR::asr_t &)asr);
     } catch (const CodeGenError &e) {

--- a/src/libasr/codegen/asr_to_c.h
+++ b/src/libasr/codegen/asr_to_c.h
@@ -2,11 +2,12 @@
 #define LFORTRAN_ASR_TO_C_H
 
 #include <libasr/asr.h>
+#include <libasr/utils.h>
 
 namespace LFortran {
 
     Result<std::string> asr_to_c(Allocator &al, ASR::TranslationUnit_t &asr,
-        diag::Diagnostics &diagnostics);
+        diag::Diagnostics &diagnostics, Platform &platform);
 
 } // namespace LFortran
 

--- a/src/libasr/codegen/asr_to_c.h
+++ b/src/libasr/codegen/asr_to_c.h
@@ -7,7 +7,8 @@
 namespace LFortran {
 
     Result<std::string> asr_to_c(Allocator &al, ASR::TranslationUnit_t &asr,
-        diag::Diagnostics &diagnostics, Platform &platform);
+        diag::Diagnostics &diagnostics, Platform &platform,
+        int64_t default_lower_bound);
 
 } // namespace LFortran
 

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -89,12 +89,14 @@ public:
     std::set<std::string> headers;
 
     SymbolTable* global_scope;
+    int64_t lower_bound;
 
     BaseCCPPVisitor(diag::Diagnostics &diag, Platform &platform,
-            bool gen_stdstring, bool gen_stdcomplex, bool is_c) : diag{diag},
+            bool gen_stdstring, bool gen_stdcomplex, bool is_c,
+            int64_t default_lower_bound) : diag{diag},
             platform{platform},
         gen_stdstring{gen_stdstring}, gen_stdcomplex{gen_stdcomplex},
-        is_c{is_c}, global_scope{nullptr} {}
+        is_c{is_c}, global_scope{nullptr}, lower_bound{default_lower_bound} {}
 
     void visit_TranslationUnit(const ASR::TranslationUnit_t &x) {
         global_scope = x.m_global_scope;
@@ -598,10 +600,7 @@ R"(#include <stdio.h>
                 src = "/* FIXME right index */";
             }
             out += src;
-            if( m_dims[i].m_start ) {
-                this->visit_expr(*m_dims[i].m_start);
-                out += " - " + src;
-            }
+            out += " - " + std::to_string(lower_bound);
             if (i < x.n_args-1) out += "][";
         }
         out += "]";

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -13,6 +13,7 @@
 
 #include <iostream>
 #include <memory>
+#include <set>
 
 #include <libasr/asr.h>
 #include <libasr/containers.h>
@@ -36,6 +37,12 @@ namespace {
     public:
         CodeGenError(const std::string &msg)
             : d{diag::Diagnostic(msg, diag::Level::Error, diag::Stage::CodeGen)}
+        { }
+
+        CodeGenError(const std::string &msg, const Location &loc)
+            : d{diag::Diagnostic(msg, diag::Level::Error, diag::Stage::CodeGen, {
+                diag::Label("", {loc})
+            })}
         { }
     };
 
@@ -62,6 +69,7 @@ private:
     Derived& self() { return static_cast<Derived&>(*this); }
 public:
     diag::Diagnostics &diag;
+    Platform platform;
     std::string src;
     int indentation_level;
     int indentation_spaces;
@@ -78,13 +86,18 @@ public:
     // Use std::complex<float/double> or float/double complex
     bool gen_stdcomplex;
     bool is_c;
+    std::set<std::string> headers;
 
-    BaseCCPPVisitor(diag::Diagnostics &diag,
+    SymbolTable* global_scope;
+
+    BaseCCPPVisitor(diag::Diagnostics &diag, Platform &platform,
             bool gen_stdstring, bool gen_stdcomplex, bool is_c) : diag{diag},
+            platform{platform},
         gen_stdstring{gen_stdstring}, gen_stdcomplex{gen_stdcomplex},
-        is_c{is_c} {}
+        is_c{is_c}, global_scope{nullptr} {}
 
     void visit_TranslationUnit(const ASR::TranslationUnit_t &x) {
+        global_scope = x.m_global_scope;
         // All loose statements must be converted to a function, so the items
         // must be empty:
         LFORTRAN_ASSERT(x.n_items == 0);
@@ -99,10 +112,6 @@ R"(#include <stdio.h>
 #include <lfortran_intrinsics.h>
 )";
         unit_src += headers;
-
-
-        // TODO: We need to pre-declare all functions first, then generate code
-        // Otherwise some function might not be found.
 
         {
             // Process intrinsic modules in the right order
@@ -158,8 +167,10 @@ R"(#include <stdio.h>
         } else {
             intrinsic_module = false;
         }
-        // Generate code for nested subroutines and functions first:
+
         std::string contains;
+
+        // Generate the bodies of subroutines
         for (auto &item : x.m_symtab->get_scope()) {
             if (ASR::is_a<ASR::Subroutine_t>(*item.second)) {
                 ASR::Subroutine_t *s = ASR::down_cast<ASR::Subroutine_t>(item.second);
@@ -218,26 +229,113 @@ R"(#include <stdio.h>
         indentation_level -= 2;
     }
 
-    void visit_Subroutine(const ASR::Subroutine_t &x) {
-        indentation_level += 1;
+    // Returns the declaration, no semi colon at the end
+    std::string get_subroutine_declaration(const ASR::Subroutine_t &x) {
         std::string sym_name = x.m_name;
         if (sym_name == "main") {
             sym_name = "_xx_lcompilers_changed_main_xx";
+        }
+        if (sym_name == "exit") {
+            sym_name = "_xx_lcompilers_changed_exit_xx";
         }
         std::string sub = "void " + sym_name + "(";
         for (size_t i=0; i<x.n_args; i++) {
             ASR::Variable_t *arg = LFortran::ASRUtils::EXPR2VAR(x.m_args[i]);
             LFORTRAN_ASSERT(ASRUtils::is_arg_dummy(arg->m_intent));
-            sub += self().convert_variable_decl(*arg);
+            sub += self().convert_variable_decl(*arg, false);
             if (i < x.n_args-1) sub += ", ";
         }
         sub += ")";
+        return sub;
+    }
+
+    // Returns the declaration, no semi colon at the end
+    std::string get_function_declaration(const ASR::Function_t &x) {
+        std::string sub;
+        ASR::Variable_t *return_var = LFortran::ASRUtils::EXPR2VAR(x.m_return_var);
+        if (ASRUtils::is_integer(*return_var->m_type)) {
+            int kind = ASR::down_cast<ASR::Integer_t>(return_var->m_type)->m_kind;
+            switch (kind) {
+                case (1) : sub = "int8_t "; break;
+                case (2) : sub = "int16_t "; break;
+                case (4) : sub = "int32_t "; break;
+                case (8) : sub = "int64_t "; break;
+            }
+        } else if (ASRUtils::is_real(*return_var->m_type)) {
+            bool is_float = ASR::down_cast<ASR::Real_t>(return_var->m_type)->m_kind == 4;
+            if (is_float) {
+                sub = "float ";
+            } else {
+                sub = "double ";
+            }
+        } else if (ASRUtils::is_logical(*return_var->m_type)) {
+            sub = "bool ";
+        } else if (ASRUtils::is_character(*return_var->m_type)) {
+            if (gen_stdstring) {
+                sub = "std::string ";
+            } else {
+                sub = "char* ";
+            }
+        } else if (ASRUtils::is_complex(*return_var->m_type)) {
+            bool is_float = ASR::down_cast<ASR::Complex_t>(return_var->m_type)->m_kind == 4;
+            if (is_float) {
+                if (gen_stdcomplex) {
+                    sub = "std::complex<float> ";
+                } else {
+                    sub = "float complex ";
+                }
+            } else {
+                if (gen_stdcomplex) {
+                    sub = "std::complex<double> ";
+                } else {
+                    sub = "double complex ";
+                }
+            }
+        } else if (ASR::is_a<ASR::CPtr_t>(*return_var->m_type)) {
+            sub = "void* ";
+        } else {
+            throw CodeGenError("Return type not supported in function '" +
+                std::string(x.m_name) +
+                + "'", return_var->base.base.loc);
+        }
+        std::string sym_name = x.m_name;
+        if (sym_name == "main") {
+            sym_name = "_xx_lcompilers_changed_main_xx";
+        }
+        sub = sub + sym_name + "(";
+        for (size_t i=0; i<x.n_args; i++) {
+            ASR::Variable_t *arg = LFortran::ASRUtils::EXPR2VAR(x.m_args[i]);
+            LFORTRAN_ASSERT(LFortran::ASRUtils::is_arg_dummy(arg->m_intent));
+            sub += self().convert_variable_decl(*arg, false);
+            if (i < x.n_args-1) sub += ", ";
+        }
+        sub += ")";
+        return sub;
+    }
+
+    std::string declare_all_functions(const SymbolTable &scope) {
+        std::string code;
+        for (auto &item : scope.get_scope()) {
+            if (ASR::is_a<ASR::Subroutine_t>(*item.second)) {
+                ASR::Subroutine_t *s = ASR::down_cast<ASR::Subroutine_t>(item.second);
+                code += get_subroutine_declaration(*s) + ";\n";
+            }
+            if (ASR::is_a<ASR::Function_t>(*item.second)) {
+                ASR::Function_t *s = ASR::down_cast<ASR::Function_t>(item.second);
+                code += get_function_declaration(*s) + ";\n";
+            }
+        }
+        return code;
+    }
+
+    void visit_Subroutine(const ASR::Subroutine_t &x) {
+        indentation_level += 1;
+        std::string sub = get_subroutine_declaration(x);
         if (x.m_abi == ASR::abiType::BindC
                 && x.m_deftype == ASR::deftypeType::Interface) {
             sub += ";\n";
         } else {
             sub += "\n";
-
             for (auto &item : x.m_symtab->get_scope()) {
                 if (ASR::is_a<ASR::Variable_t>(*item.second)) {
                     ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(item.second);
@@ -302,60 +400,7 @@ R"(#include <stdio.h>
             s.intrinsic_function = false;
             sym_info[get_hash((ASR::asr_t*)&x)] = s;
         }
-        std::string sub;
-        ASR::Variable_t *return_var = LFortran::ASRUtils::EXPR2VAR(x.m_return_var);
-        if (ASRUtils::is_integer(*return_var->m_type)) {
-            bool is_int = ASR::down_cast<ASR::Integer_t>(return_var->m_type)->m_kind == 4;
-            if (is_int) {
-                sub = "int ";
-            } else {
-                sub = "long long ";
-            }
-        } else if (ASRUtils::is_real(*return_var->m_type)) {
-            bool is_float = ASR::down_cast<ASR::Real_t>(return_var->m_type)->m_kind == 4;
-            if (is_float) {
-                sub = "float ";
-            } else {
-                sub = "double ";
-            }
-        } else if (ASRUtils::is_logical(*return_var->m_type)) {
-            sub = "bool ";
-        } else if (ASRUtils::is_character(*return_var->m_type)) {
-            if (gen_stdstring) {
-                sub = "std::string ";
-            } else {
-                sub = "char* ";
-            }
-        } else if (ASRUtils::is_complex(*return_var->m_type)) {
-            bool is_float = ASR::down_cast<ASR::Complex_t>(return_var->m_type)->m_kind == 4;
-            if (is_float) {
-                if (gen_stdcomplex) {
-                    sub = "std::complex<float> ";
-                } else {
-                    sub = "float complex ";
-                }
-            } else {
-                if (gen_stdcomplex) {
-                    sub = "std::complex<double> ";
-                } else {
-                    sub = "double complex ";
-                }
-            }
-        } else {
-            throw CodeGenError("Return type not supported");
-        }
-        std::string sym_name = x.m_name;
-        if (sym_name == "main") {
-            sym_name = "_xx_lcompilers_changed_main_xx";
-        }
-        sub = sub + sym_name + "(";
-        for (size_t i=0; i<x.n_args; i++) {
-            ASR::Variable_t *arg = LFortran::ASRUtils::EXPR2VAR(x.m_args[i]);
-            LFORTRAN_ASSERT(LFortran::ASRUtils::is_arg_dummy(arg->m_intent));
-            sub += self().convert_variable_decl(*arg);
-            if (i < x.n_args-1) sub += ", ";
-        }
-        sub += ")";
+        std::string sub = get_function_declaration(x);
         if (x.m_abi == ASR::abiType::BindC
                 && x.m_deftype == ASR::deftypeType::Interface) {
             sub += ";\n";
@@ -475,6 +520,9 @@ R"(#include <stdio.h>
         } else if (ASR::is_a<ASR::ArrayRef_t>(*x.m_target)) {
             visit_ArrayRef(*ASR::down_cast<ASR::ArrayRef_t>(x.m_target));
             target = src;
+        } else if (ASR::is_a<ASR::DerivedRef_t>(*x.m_target)) {
+            visit_DerivedRef(*ASR::down_cast<ASR::DerivedRef_t>(x.m_target));
+            target = src;
         } else {
             LFORTRAN_ASSERT(false)
         }
@@ -490,13 +538,26 @@ R"(#include <stdio.h>
     }
 
     void visit_RealConstant(const ASR::RealConstant_t &x) {
-        src = std::to_string(x.m_r);
+        src = double_to_scientific(x.m_r);
         last_expr_precedence = 2;
     }
 
 
     void visit_StringConstant(const ASR::StringConstant_t &x) {
-        src = "\"" + std::string(x.m_s) + "\"";
+        src = "\"";
+        std::string s = x.m_s;
+        for (size_t idx=0; idx < s.size(); idx++) {
+            if (s[idx] == '\n') {
+                src += "\\n";
+            } else if (s[idx] == '\\') {
+                src += "\\\\";
+            } else if (s[idx] == '\"') {
+                src += "\\\"";
+            } else {
+                src += s[idx];
+            }
+        }
+        src += "\"";
         last_expr_precedence = 2;
     }
 
@@ -515,9 +576,20 @@ R"(#include <stdio.h>
         last_expr_precedence = 2;
     }
 
+    void visit_DerivedRef(const ASR::DerivedRef_t& x) {
+        std::string der_expr, member;
+        this->visit_expr(*x.m_v);
+        der_expr = std::move(src);
+        member = ASRUtils::symbol_name(x.m_m);
+        src = der_expr + "->" + member;
+    }
+
     void visit_ArrayRef(const ASR::ArrayRef_t &x) {
         const ASR::symbol_t *s = ASRUtils::symbol_get_past_external(x.m_v);
-        std::string out = ASR::down_cast<ASR::Variable_t>(s)->m_name;
+        ASR::Variable_t* sv = ASR::down_cast<ASR::Variable_t>(s);
+        std::string out = std::string(sv->m_name);
+        ASR::dimension_t* m_dims;
+        ASRUtils::extract_dimensions_from_ttype(sv->m_type, m_dims);
         out += "[";
         for (size_t i=0; i<x.n_args; i++) {
             if (x.m_args[i].m_right) {
@@ -526,9 +598,13 @@ R"(#include <stdio.h>
                 src = "/* FIXME right index */";
             }
             out += src;
-            if (i < x.n_args-1) out += ", ";
+            if( m_dims[i].m_start ) {
+                this->visit_expr(*m_dims[i].m_start);
+                out += " - " + src;
+            }
+            if (i < x.n_args-1) out += "][";
         }
-        out += "-1]";
+        out += "]";
         last_expr_precedence = 2;
         src = out;
     }
@@ -557,20 +633,69 @@ R"(#include <stdio.h>
             case (ASR::cast_kindType::ComplexToComplex) : {
                 break;
             }
+            case (ASR::cast_kindType::IntegerToComplex) : {
+                if (is_c) {
+                    headers.insert("complex");
+                    src = "CMPLX(" + src + ", 0)";
+                } else {
+                    src = "std::complex<double>(" + src + ")";
+                }
+                break;
+            }
             case (ASR::cast_kindType::ComplexToReal) : {
-                src = "creal(" + src + ")";
+                if (is_c) {
+                    headers.insert("complex");
+                    src = "creal(" + src + ")";
+                } else {
+                    src = "std::real(" + src + ")";
+                }
+                break;
+            }
+            case (ASR::cast_kindType::RealToComplex) : {
+                if (is_c) {
+                    headers.insert("complex");
+                    src = "CMPLX(" + src + ", 0.0)";
+                } else {
+                    src = "std::complex<double>(" + src + ")";
+                }
                 break;
             }
             case (ASR::cast_kindType::LogicalToInteger) : {
                 src = "(int)(" + src + ")";
                 break;
             }
-            default : throw CodeGenError("Cast kind " + std::to_string(x.m_kind) + " not implemented");
+            case (ASR::cast_kindType::IntegerToLogical) : {
+                src = "(bool)(" + src + ")";
+                break;
+            }
+            default : throw CodeGenError("Cast kind " + std::to_string(x.m_kind) + " not implemented",
+                x.base.base.loc);
         }
         last_expr_precedence = 2;
     }
 
-    void visit_Compare(const ASR::Compare_t &x) {
+    void visit_IntegerCompare(const ASR::IntegerCompare_t &x) {
+        handle_Compare(x);
+    }
+
+    void visit_RealCompare(const ASR::RealCompare_t &x) {
+        handle_Compare(x);
+    }
+
+    void visit_ComplexCompare(const ASR::ComplexCompare_t &x) {
+        handle_Compare(x);
+    }
+
+    void visit_LogicalCompare(const ASR::LogicalCompare_t &x) {
+        handle_Compare(x);
+    }
+
+    void visit_StringCompare(const ASR::StringCompare_t &x) {
+        handle_Compare(x);
+    }
+
+    template<typename T>
+    void handle_Compare(const T &x) {
         self().visit_expr(*x.m_left);
         std::string left = std::move(src);
         int left_precedence = last_expr_precedence;
@@ -596,45 +721,6 @@ R"(#include <stdio.h>
             src += right;
         } else {
             src += "(" + right + ")";
-        }
-    }
-
-    void visit_UnaryOp(const ASR::UnaryOp_t &x) {
-        self().visit_expr(*x.m_operand);
-        int expr_precedence = last_expr_precedence;
-        if (x.m_type->type == ASR::ttypeType::Integer) {
-            if (x.m_op == ASR::unaryopType::UAdd) {
-                // src = src;
-                // Skip unary plus, keep the previous precedence
-
-            } else if (x.m_op == ASR::unaryopType::Not) {
-                last_expr_precedence = 3;
-                if (expr_precedence <= last_expr_precedence) {
-                    src = "!" + src;
-                } else {
-                    src = "!(" + src + ")";
-                }
-            } else {
-                throw CodeGenError("Unary type not implemented yet for Integer");
-            }
-            return;
-        } else if (x.m_type->type == ASR::ttypeType::Real) {
-            if (x.m_op == ASR::unaryopType::UAdd) {
-                // src = src;
-                // Skip unary plus, keep the previous precedence
-            } else if (x.m_op == ASR::unaryopType::Not) {
-                last_expr_precedence = 3;
-                if (expr_precedence <= last_expr_precedence) {
-                    src = "!" + src;
-                } else {
-                    src = "!(" + src + ")";
-                }
-            } else {
-                throw CodeGenError("Unary type not implemented yet for Real");
-            }
-            return;
-        } else {
-            throw CodeGenError("UnaryOp: type not supported yet");
         }
     }
 
@@ -680,7 +766,77 @@ R"(#include <stdio.h>
         }
     }
 
-    void visit_BinOp(const ASR::BinOp_t &x) {
+    std::string get_c_type_from_ttype_t(ASR::ttype_t* t) {
+        int kind = ASRUtils::extract_kind_from_ttype_t(t);
+        std::string type_src = "";
+        switch( t->type ) {
+            case ASR::ttypeType::Integer: {
+                type_src = "int" + std::to_string(kind * 8) + "_t";
+                break;
+            }
+            case ASR::ttypeType::Pointer: {
+                ASR::Pointer_t* ptr_type = ASR::down_cast<ASR::Pointer_t>(t);
+                type_src = get_c_type_from_ttype_t(ptr_type->m_type) + "*";
+                break;
+            }
+            case ASR::ttypeType::CPtr: {
+                type_src = "void*";
+                break;
+            }
+            case ASR::ttypeType::Derived: {
+                ASR::Derived_t* der_type = ASR::down_cast<ASR::Derived_t>(t);
+                type_src = std::string("struct ") + ASRUtils::symbol_name(der_type->m_derived_type);
+                break;
+            }
+            default: {
+                throw CodeGenError("Type " + ASRUtils::type_to_str_python(t) + " not supported yet.");
+            }
+        }
+        return type_src;
+    }
+
+    void visit_GetPointer(const ASR::GetPointer_t& x) {
+        self().visit_expr(*x.m_arg);
+        std::string arg_src = std::move(src);
+        std::string addr_prefix = "&";
+        if( ASRUtils::is_array(ASRUtils::expr_type(x.m_arg)) ||
+            ASR::is_a<ASR::Derived_t>(*ASRUtils::expr_type(x.m_arg)) ) {
+            addr_prefix.clear();
+        }
+        src = addr_prefix + arg_src;
+    }
+
+    void visit_PointerToCPtr(const ASR::PointerToCPtr_t& x) {
+        self().visit_expr(*x.m_arg);
+        std::string arg_src = std::move(src);
+        std::string type_src = get_c_type_from_ttype_t(x.m_type);
+        src = "(" + type_src + ") " + arg_src;
+    }
+
+    void visit_CPtrToPointer(const ASR::CPtrToPointer_t& x) {
+        self().visit_expr(*x.m_cptr);
+        std::string source_src = std::move(src);
+        self().visit_expr(*x.m_ptr);
+        std::string dest_src = std::move(src);
+        std::string type_src = get_c_type_from_ttype_t(ASRUtils::expr_type(x.m_ptr));
+        std::string indent(indentation_level*indentation_spaces, ' ');
+        src = indent + dest_src + " = (" + type_src + ") " + source_src + ";\n";
+    }
+
+    void visit_IntegerBinOp(const ASR::IntegerBinOp_t &x) {
+        handle_BinOp(x);
+    }
+
+    void visit_RealBinOp(const ASR::RealBinOp_t &x) {
+        handle_BinOp(x);
+    }
+
+    void visit_ComplexBinOp(const ASR::ComplexBinOp_t &x) {
+        handle_BinOp(x);
+    }
+
+    template <typename T>
+    void handle_BinOp(const T &x) {
         self().visit_expr(*x.m_left);
         std::string left = std::move(src);
         int left_precedence = last_expr_precedence;
@@ -694,7 +850,11 @@ R"(#include <stdio.h>
             case (ASR::binopType::Div) : { last_expr_precedence = 5; break; }
             case (ASR::binopType::Pow) : {
                 src = "pow(" + left + ", " + right + ")";
-                if (!is_c) src = "std::" + src;
+                if (is_c) {
+                    headers.insert("math");
+                } else {
+                    src = "std::" + src;
+                }
                 return;
             }
             default: throw CodeGenError("BinOp: operator not implemented yet");
@@ -709,7 +869,7 @@ R"(#include <stdio.h>
                 src += "(" + left + ")";
             }
         }
-        src += ASRUtils::binop_to_str(x.m_op);
+        src += ASRUtils::binop_to_str_python(x.m_op);
         if (right_precedence == 3) {
             src += "(" + right + ")";
         } else if (x.m_op == ASR::binopType::Sub) {
@@ -727,7 +887,7 @@ R"(#include <stdio.h>
         }
     }
 
-    void visit_BoolOp(const ASR::BoolOp_t &x) {
+    void visit_LogicalBinOp(const ASR::LogicalBinOp_t &x) {
         self().visit_expr(*x.m_left);
         std::string left = std::move(src);
         int left_precedence = last_expr_precedence;
@@ -735,19 +895,19 @@ R"(#include <stdio.h>
         std::string right = std::move(src);
         int right_precedence = last_expr_precedence;
         switch (x.m_op) {
-            case (ASR::boolopType::And): {
+            case (ASR::logicalbinopType::And): {
                 last_expr_precedence = 14;
                 break;
             }
-            case (ASR::boolopType::Or): {
+            case (ASR::logicalbinopType::Or): {
                 last_expr_precedence = 15;
                 break;
             }
-            case (ASR::boolopType::NEqv): {
+            case (ASR::logicalbinopType::NEqv): {
                 last_expr_precedence = 10;
                 break;
             }
-            case (ASR::boolopType::Eqv): {
+            case (ASR::logicalbinopType::Eqv): {
                 last_expr_precedence = 10;
                 break;
             }
@@ -759,64 +919,12 @@ R"(#include <stdio.h>
         } else {
             src += "(" + left + ")";
         }
-        src += ASRUtils::boolop_to_str(x.m_op);
+        src += ASRUtils::logicalbinop_to_str_python(x.m_op);
         if (right_precedence <= last_expr_precedence) {
             src += right;
         } else {
             src += "(" + right + ")";
         }
-    }
-
-    std::string get_print_type(ASR::ttype_t *t) {
-        switch (t->type) {
-            case ASR::ttypeType::Integer: {
-                ASR::Integer_t *i = (ASR::Integer_t*)t;
-                switch (i->m_kind) {
-                    case 1: { return "%d"; }
-                    case 2: { return "%d"; }
-                    case 4: { return "%d"; }
-                    case 8: { return "%lli"; }
-                    default: { throw LFortranException("Integer kind not supported"); }
-                }
-            }
-            case ASR::ttypeType::Real: {
-                ASR::Real_t *r = (ASR::Real_t*)t;
-                switch (r->m_kind) {
-                    case 4: { return "%f"; }
-                    case 8: { return "%lf"; }
-                    default: { throw LFortranException("Float kind not supported"); }
-                }
-            }
-            case ASR::ttypeType::Logical: {
-                return "%d";
-            }
-            case ASR::ttypeType::Character: {
-                return "%s";
-            }
-            default : throw LFortranException("Not implemented");
-        }
-    }
-
-    void visit_Print(const ASR::Print_t &x) {
-        std::string indent(indentation_level*indentation_spaces, ' ');
-        std::string out = indent + "printf(\"";
-        std::vector<std::string> v;
-        for (size_t i=0; i<x.n_values; i++) {
-            self().visit_expr(*x.m_values[i]);
-            out += get_print_type(ASRUtils::expr_type(x.m_values[i]));
-            if (i+1!=x.n_values) {
-                out += " ";
-            }
-            v.push_back(src);
-        }
-        out += "\\n\"";
-        if (!v.empty()) {
-            for (auto s: v) {
-                out += ", " + s;
-            }
-        }
-        out += ");\n";
-        src = out;
     }
 
     void visit_Allocate(const ASR::Allocate_t &x) {
@@ -926,6 +1034,16 @@ R"(#include <stdio.h>
         src = indent + "exit(" + src + ");\n";
     }
 
+    void visit_ErrorStop(const ASR::ErrorStop_t & /* x */) {
+        std::string indent(indentation_level*indentation_spaces, ' ');
+        if (is_c) {
+            src = indent + "fprintf(stderr, \"ERROR STOP\");\n";
+        } else {
+            src = indent + "std::cerr << \"ERROR STOP\" << std::endl;\n";
+        }
+        src += indent + "exit(1);\n";
+    }
+
     void visit_ImpliedDoLoop(const ASR::ImpliedDoLoop_t &/*x*/) {
         std::string indent(indentation_level*indentation_spaces, ' ');
         std::string out = indent + " /* FIXME: implied do loop */ ";
@@ -949,11 +1067,9 @@ R"(#include <stdio.h>
         } else {
             if (c->type == ASR::exprType::IntegerConstant) {
                 increment = ASR::down_cast<ASR::IntegerConstant_t>(c)->m_n;
-            } else if (c->type == ASR::exprType::UnaryOp) {
-                ASR::UnaryOp_t *u = ASR::down_cast<ASR::UnaryOp_t>(c);
-                LFORTRAN_ASSERT(u->m_op == ASR::unaryopType::USub);
-                LFORTRAN_ASSERT(u->m_operand->type == ASR::exprType::IntegerConstant);
-                increment = - ASR::down_cast<ASR::IntegerConstant_t>(u->m_operand)->m_n;
+            } else if (c->type == ASR::exprType::IntegerUnaryMinus) {
+                ASR::IntegerUnaryMinus_t *ium = ASR::down_cast<ASR::IntegerUnaryMinus_t>(c);
+                increment = - ASR::down_cast<ASR::IntegerConstant_t>(ium->m_arg)->m_n;
             } else {
                 throw CodeGenError("Do loop increment type not supported");
             }
@@ -986,12 +1102,6 @@ R"(#include <stdio.h>
         out += indent + "}\n";
         indentation_level -= 1;
         src = out;
-    }
-
-    void visit_ErrorStop(const ASR::ErrorStop_t & /* x */) {
-        std::string indent(indentation_level*indentation_spaces, ' ');
-        src = indent + "fprintf(stderr, \"ERROR STOP\");\n";
-        src += indent + "exit(1);\n";
     }
 
     void visit_If(const ASR::If_t &x) {
@@ -1037,7 +1147,12 @@ R"(#include <stdio.h>
         std::string indent(indentation_level*indentation_spaces, ' ');
         ASR::Subroutine_t *s = ASR::down_cast<ASR::Subroutine_t>(
             LFortran::ASRUtils::symbol_get_past_external(x.m_name));
-        std::string out = indent + s->m_name + "(";
+        // TODO: use a mapping with a hash(s) instead:
+        std::string sym_name = s->m_name;
+        if (sym_name == "exit") {
+            sym_name = "_xx_lcompilers_changed_exit_xx";
+        }
+        std::string out = indent + sym_name + "(";
         for (size_t i=0; i<x.n_args; i++) {
             if (ASR::is_a<ASR::Var_t>(*x.m_args[i].m_value)) {
                 ASR::Variable_t *arg = LFortran::ASRUtils::EXPR2VAR(x.m_args[i].m_value);

--- a/src/libasr/codegen/asr_to_cpp.cpp
+++ b/src/libasr/codegen/asr_to_cpp.cpp
@@ -13,33 +13,6 @@
 
 namespace LFortran {
 
-std::string convert_dims(size_t n_dims, ASR::dimension_t *m_dims)
-{
-    std::string dims;
-    for (size_t i=0; i<n_dims; i++) {
-        ASR::expr_t *start = m_dims[i].m_start;
-        ASR::expr_t *end = m_dims[i].m_end;
-        if (!start && !end) {
-            dims += "*";
-        } else if (start && end) {
-            if (ASR::is_a<ASR::IntegerConstant_t>(*start) && ASR::is_a<ASR::IntegerConstant_t>(*end)) {
-                ASR::IntegerConstant_t *s = ASR::down_cast<ASR::IntegerConstant_t>(start);
-                ASR::IntegerConstant_t *e = ASR::down_cast<ASR::IntegerConstant_t>(end);
-                if (s->m_n == 1) {
-                    dims += "[" + std::to_string(e->m_n) + "]";
-                } else {
-                    throw CodeGenError("Lower dimension must be 1 for now");
-                }
-            } else {
-                dims += "[ /* FIXME symbolic dimensions */ ]";
-            }
-        } else {
-            throw CodeGenError("Dimension type not supported");
-        }
-    }
-    return dims;
-}
-
 std::string format_type(const std::string &dims, const std::string &type,
         const std::string &name, bool use_ref, bool dummy)
 {
@@ -64,8 +37,36 @@ std::string format_type(const std::string &dims, const std::string &type,
 class ASRToCPPVisitor : public BaseCCPPVisitor<ASRToCPPVisitor>
 {
 public:
-    ASRToCPPVisitor(diag::Diagnostics &diag, Platform &platform)
-        : BaseCCPPVisitor(diag, platform, true, true, false) {}
+    ASRToCPPVisitor(diag::Diagnostics &diag, Platform &platform,
+                    int64_t default_lower_bound)
+        : BaseCCPPVisitor(diag, platform, true, true, false,
+                          default_lower_bound) {}
+
+    std::string convert_dims(size_t n_dims, ASR::dimension_t *m_dims)
+    {
+        std::string dims;
+        for (size_t i=0; i<n_dims; i++) {
+            ASR::expr_t *start = m_dims[i].m_start;
+            ASR::expr_t *end = m_dims[i].m_end;
+            if (!start && !end) {
+                dims += "*";
+            } else if (start && end) {
+                ASR::expr_t* start_value = ASRUtils::expr_value(start);
+                ASR::expr_t* end_value = ASRUtils::expr_value(end);
+                if( start_value && end_value ) {
+                    int64_t start_int = -1, end_int = -1;
+                    ASRUtils::extract_value(start_value, start_int);
+                    ASRUtils::extract_value(end_value, end_int);
+                    dims += "[" + std::to_string(end_int - start_int + 1) + "]";
+                } else {
+                    dims += "[ /* FIXME symbolic dimensions */ ]";
+                }
+            } else {
+                throw CodeGenError("Dimension type not supported");
+            }
+        }
+        return dims;
+    }
 
     std::string convert_variable_decl(const ASR::Variable_t &v, bool use_static=true)
     {
@@ -443,10 +444,11 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
 };
 
 Result<std::string> asr_to_cpp(Allocator &al, ASR::TranslationUnit_t &asr,
-    diag::Diagnostics &diagnostics, Platform &platform)
+    diag::Diagnostics &diagnostics, Platform &platform,
+    int64_t default_lower_bound)
 {
     pass_unused_functions(al, asr, true);
-    ASRToCPPVisitor v(diagnostics, platform);
+    ASRToCPPVisitor v(diagnostics, platform, default_lower_bound);
     try {
         v.visit_asr((ASR::asr_t &)asr);
     } catch (const CodeGenError &e) {

--- a/src/libasr/codegen/asr_to_cpp.h
+++ b/src/libasr/codegen/asr_to_cpp.h
@@ -2,11 +2,12 @@
 #define LFORTRAN_ASR_TO_CPP_H
 
 #include <libasr/asr.h>
+#include <libasr/utils.h>
 
 namespace LFortran {
 
     Result<std::string> asr_to_cpp(Allocator &al, ASR::TranslationUnit_t &asr,
-        diag::Diagnostics &diagnostics);
+        diag::Diagnostics &diagnostics, Platform &platform);
 
 } // namespace LFortran
 

--- a/src/libasr/codegen/asr_to_cpp.h
+++ b/src/libasr/codegen/asr_to_cpp.h
@@ -7,7 +7,7 @@
 namespace LFortran {
 
     Result<std::string> asr_to_cpp(Allocator &al, ASR::TranslationUnit_t &asr,
-        diag::Diagnostics &diagnostics, Platform &platform);
+        diag::Diagnostics &diagnostics, Platform &platform, int64_t default_lower_bound);
 
 } // namespace LFortran
 

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -41,18 +41,12 @@
 #include <libasr/asr.h>
 #include <libasr/containers.h>
 #include <libasr/codegen/asr_to_llvm.h>
-#include <libasr/pass/do_loops.h>
-#include <libasr/pass/for_all.h>
 #include <libasr/pass/nested_vars.h>
 #include <libasr/pass/pass_manager.h>
 #include <libasr/exception.h>
 #include <libasr/asr_utils.h>
 #include <libasr/codegen/llvm_utils.h>
 #include <libasr/codegen/llvm_array_utils.h>
-
-// Uncomment for ASR printing below
-//#include <lfortran/pickle.h>
-// #include <lpython/pickle.h>
 
 #if LLVM_VERSION_MAJOR >= 11
 #    define FIXED_VECTOR_TYPE llvm::FixedVectorType
@@ -1258,7 +1252,8 @@ public:
         std::vector<llvm::Value*> idx_vec = {
             llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
             llvm::ConstantInt::get(context, llvm::APInt(32, member_idx))};
-        if( ASR::is_a<ASR::DerivedRef_t>(*x.m_v) ) {
+        if( ASR::is_a<ASR::DerivedRef_t>(*x.m_v) &&
+            is_nested_pointer(tmp) ) {
             tmp = builder->CreateLoad(tmp);
         }
         llvm::Value* tmp1 = CreateGEP(tmp, idx_vec);
@@ -2597,13 +2592,19 @@ public:
         }
     }
 
+    bool is_nested_pointer(llvm::Value* val) {
+        // TODO: Remove this in future
+        // Related issue, https://github.com/lcompilers/lpython/pull/707#issuecomment-1169773106.
+        return val->getType()->isPointerTy() &&
+               val->getType()->getContainedType(0)->isPointerTy();
+    }
+
     void visit_CLoc(const ASR::CLoc_t& x) {
         uint64_t ptr_loads_copy = ptr_loads;
         ptr_loads = 0;
         this->visit_expr(*x.m_arg);
         ptr_loads = ptr_loads_copy;
-        if( tmp->getType()->isPointerTy() &&
-            tmp->getType()->getContainedType(0)->isPointerTy() ) {
+        if( is_nested_pointer(tmp) ) {
             tmp = builder->CreateLoad(tmp);
         }
         if( arr_descr->is_array(tmp) ) {
@@ -2615,8 +2616,7 @@ public:
 
 
     llvm::Value* GetPointerCPtrUtil(llvm::Value* llvm_tmp) {
-        if( llvm_tmp->getType()->isPointerTy() &&
-            llvm_tmp->getType()->getContainedType(0)->isPointerTy() ) {
+        if( is_nested_pointer(llvm_tmp) ) {
             llvm_tmp = builder->CreateLoad(llvm_tmp);
         }
         if( arr_descr->is_array(llvm_tmp) ) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -43,23 +43,8 @@
 #include <libasr/codegen/asr_to_llvm.h>
 #include <libasr/pass/do_loops.h>
 #include <libasr/pass/for_all.h>
-#include <libasr/pass/implied_do_loops.h>
-#include <libasr/pass/array_op.h>
-#include <libasr/pass/select_case.h>
-#include <libasr/pass/global_stmts.h>
-#include <libasr/pass/param_to_const.h>
 #include <libasr/pass/nested_vars.h>
-#include <libasr/pass/print_arr.h>
-#include <libasr/pass/arr_slice.h>
-#include <libasr/pass/flip_sign.h>
-#include <libasr/pass/div_to_mul.h>
-#include <libasr/pass/fma.h>
-#include <libasr/pass/loop_unroll.h>
-#include <libasr/pass/sign_from_value.h>
-#include <libasr/pass/class_constructor.h>
-#include <libasr/pass/unused_functions.h>
-#include <libasr/pass/inline_function_calls.h>
-#include <libasr/pass/dead_code_removal.h>
+#include <libasr/pass/pass_manager.h>
 #include <libasr/exception.h>
 #include <libasr/asr_utils.h>
 #include <libasr/codegen/llvm_utils.h>
@@ -67,6 +52,7 @@
 
 // Uncomment for ASR printing below
 //#include <lfortran/pickle.h>
+// #include <lpython/pickle.h>
 
 #if LLVM_VERSION_MAJOR >= 11
 #    define FIXED_VECTOR_TYPE llvm::FixedVectorType
@@ -523,6 +509,46 @@ public:
         return nullptr;
     }
 
+    llvm::Type* getMemberType(ASR::ttype_t* mem_type, ASR::Variable_t* member) {
+        llvm::Type* llvm_mem_type = nullptr;
+        switch( mem_type->type ) {
+            case ASR::ttypeType::Integer: {
+                int a_kind = down_cast<ASR::Integer_t>(mem_type)->m_kind;
+                llvm_mem_type = getIntType(a_kind);
+                break;
+            }
+            case ASR::ttypeType::Real: {
+                int a_kind = down_cast<ASR::Real_t>(mem_type)->m_kind;
+                llvm_mem_type = getFPType(a_kind);
+                break;
+            }
+            case ASR::ttypeType::Derived: {
+                llvm_mem_type = getDerivedType(mem_type);
+                break;
+            }
+            case ASR::ttypeType::Pointer: {
+                ASR::Pointer_t* ptr_type = ASR::down_cast<ASR::Pointer_t>(mem_type);
+                llvm_mem_type = getMemberType(ptr_type->m_type, member)->getPointerTo();
+                break;
+            }
+            case ASR::ttypeType::Complex: {
+                int a_kind = down_cast<ASR::Complex_t>(mem_type)->m_kind;
+                llvm_mem_type = getComplexType(a_kind);
+                break;
+            }
+            case ASR::ttypeType::Character: {
+                llvm_mem_type = character_type;
+                break;
+            }
+            default:
+                throw CodeGenError("Cannot identify the type of member, '" +
+                                    std::string(member->m_name) +
+                                    "' in derived type, '" + der_type_name + "'.",
+                                    member->base.base.loc);
+        }
+        return llvm_mem_type;
+    }
+
     llvm::Type* getDerivedType(ASR::DerivedType_t* der_type, bool is_pointer=false) {
         std::string der_type_name = std::string(der_type->m_name);
         llvm::StructType* der_type_llvm;
@@ -542,38 +568,8 @@ public:
             const std::map<std::string, ASR::symbol_t*>& scope = der_type->m_symtab->get_scope();
             for( auto itr = scope.begin(); itr != scope.end(); itr++ ) {
                 ASR::Variable_t* member = (ASR::Variable_t*)(&(itr->second->base));
-                llvm::Type* mem_type = nullptr;
-                switch( member->m_type->type ) {
-                    case ASR::ttypeType::Integer: {
-                        int a_kind = down_cast<ASR::Integer_t>(member->m_type)->m_kind;
-                        mem_type = getIntType(a_kind);
-                        break;
-                    }
-                    case ASR::ttypeType::Real: {
-                        int a_kind = down_cast<ASR::Real_t>(member->m_type)->m_kind;
-                        mem_type = getFPType(a_kind);
-                        break;
-                    }
-                    case ASR::ttypeType::Derived: {
-                        mem_type = getDerivedType(member->m_type);
-                        break;
-                    }
-                    case ASR::ttypeType::Complex: {
-                        int a_kind = down_cast<ASR::Complex_t>(member->m_type)->m_kind;
-                        mem_type = getComplexType(a_kind);
-                        break;
-                    }
-                    case ASR::ttypeType::Character: {
-                        mem_type = character_type;
-                        break;
-                    }
-                    default:
-                        throw CodeGenError("Cannot identify the type of member, '" +
-                                            std::string(member->m_name) +
-                                            "' in derived type, '" + der_type_name + "'.",
-                                            member->base.base.loc);
-                }
-                member_types.push_back(mem_type);
+                llvm::Type* llvm_mem_type = getMemberType(member->m_type, member);
+                member_types.push_back(llvm_mem_type);
                 name2memidx[der_type_name][std::string(member->m_name)] = member_idx;
                 member_idx++;
             }
@@ -1110,7 +1106,7 @@ public:
     }
 
     void visit_ListAppend(const ASR::ListAppend_t& x) {
-        ASR::Variable_t *l = ASR::down_cast<ASR::Variable_t>(x.m_a);
+        ASR::Variable_t *l = EXPR2VAR(x.m_a);
         uint32_t v_h = get_hash((ASR::asr_t*)l);
         LFORTRAN_ASSERT(llvm_symtab.find(v_h) != llvm_symtab.end());
         llvm::Value *plist = llvm_symtab[v_h];
@@ -1135,7 +1131,7 @@ public:
     }
 
     void visit_ListItem(const ASR::ListItem_t& x) {
-        ASR::Variable_t *l = ASR::down_cast<ASR::Variable_t>(x.m_a);
+        ASR::Variable_t *l = EXPR2VAR(x.m_a);
         uint32_t v_h = get_hash((ASR::asr_t*)l);
         LFORTRAN_ASSERT(llvm_symtab.find(v_h) != llvm_symtab.end());
         llvm::Value *plist = llvm_symtab[v_h];
@@ -1223,7 +1219,10 @@ public:
             std::vector<llvm::Value*> indices;
             for( size_t r = 0; r < x.n_args; r++ ) {
                 ASR::array_index_t curr_idx = x.m_args[r];
+                uint64_t ptr_loads_copy = ptr_loads;
+                ptr_loads = 2;
                 this->visit_expr_wrapper(curr_idx.m_right, true);
+                ptr_loads = ptr_loads_copy;
                 indices.push_back(tmp);
             }
             if (v->m_type->type == ASR::ttypeType::Pointer) {
@@ -1239,7 +1238,11 @@ public:
             return;
         }
         der_type_name = "";
+        ASR::ttype_t* x_m_v_type = ASRUtils::expr_type(x.m_v);
+        uint64_t ptr_loads_copy = ptr_loads;
+        ptr_loads = ptr_loads_copy - ASR::is_a<ASR::Pointer_t>(*x_m_v_type);
         this->visit_expr(*x.m_v);
+        ptr_loads = ptr_loads_copy;
         ASR::Variable_t* member = down_cast<ASR::Variable_t>(symbol_get_past_external(x.m_m));
         std::string member_name = std::string(member->m_name);
         LFORTRAN_ASSERT(der_type_name.size() != 0);
@@ -1255,9 +1258,16 @@ public:
         std::vector<llvm::Value*> idx_vec = {
             llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
             llvm::ConstantInt::get(context, llvm::APInt(32, member_idx))};
+        if( ASR::is_a<ASR::DerivedRef_t>(*x.m_v) ) {
+            tmp = builder->CreateLoad(tmp);
+        }
         llvm::Value* tmp1 = CreateGEP(tmp, idx_vec);
-        if( member->m_type->type == ASR::ttypeType::Derived ) {
-            ASR::Derived_t* der = (ASR::Derived_t*)(&(member->m_type->base));
+        ASR::ttype_t* member_type = member->m_type;
+        if( ASR::is_a<ASR::Pointer_t>(*member_type) ) {
+            member_type = ASR::down_cast<ASR::Pointer_t>(member_type)->m_type;
+        }
+        if( member_type->type == ASR::ttypeType::Derived ) {
+            ASR::Derived_t* der = (ASR::Derived_t*)(&(member_type->base));
             ASR::DerivedType_t* der_type = (ASR::DerivedType_t*)(&(der->m_derived_type->base));
             der_type_name = std::string(der_type->m_name);
             uint32_t h = get_hash((ASR::asr_t*)member);
@@ -1608,15 +1618,9 @@ public:
             }
             case (ASR::ttypeType::Pointer) : {
                 ASR::ttype_t *t2 = ASR::down_cast<ASR::Pointer_t>(asr_type)->m_type;
-                switch (t2->type) {
-                    case (ASR::ttypeType::Derived) : {
-                        throw CodeGenError("Pointers for Derived type not implemented yet in conversion.");
-                    }
-                    default :
-                        llvm_type = get_type_from_ttype_t(t2, m_storage, is_array_type,
+                llvm_type = get_type_from_ttype_t(t2, m_storage, is_array_type,
                                         is_malloc_array_type, m_dims, n_dims, a_kind);
-                        llvm_type = llvm_type->getPointerTo();
-                }
+                llvm_type = llvm_type->getPointerTo();
                 break;
             }
             case (ASR::ttypeType::List) : {
@@ -1709,8 +1713,10 @@ public:
                         // Set allocatable arrays as unallocated
                         arr_descr->set_is_allocated_flag(ptr, 0);
                     }
-                    if( v->m_symbolic_value != nullptr ) {
+                    if( v->m_symbolic_value != nullptr &&
+                        !ASR::is_a<ASR::List_t>(*v->m_type)) {
                         target_var = ptr;
+                        tmp = nullptr;
                         this->visit_expr_wrapper(v->m_symbolic_value, true);
                         llvm::Value *init_value = tmp;
                         if (ASR::is_a<ASR::ArrayConstant_t>(*v->m_symbolic_value)) {
@@ -2378,6 +2384,9 @@ public:
             case (ASR::ttypeType::Logical) :
                 return_type = llvm::Type::getInt1Ty(context);
                 break;
+            case (ASR::ttypeType::CPtr) :
+                return_type = llvm::Type::getVoidTy(context)->getPointerTo();
+                break;
             case (ASR::ttypeType::Derived) :
                 throw CodeGenError("Derived return type not implemented yet");
                 break;
@@ -2605,19 +2614,73 @@ public:
     }
 
 
+    llvm::Value* GetPointerCPtrUtil(llvm::Value* llvm_tmp) {
+        if( llvm_tmp->getType()->isPointerTy() &&
+            llvm_tmp->getType()->getContainedType(0)->isPointerTy() ) {
+            llvm_tmp = builder->CreateLoad(llvm_tmp);
+        }
+        if( arr_descr->is_array(llvm_tmp) ) {
+            llvm_tmp = builder->CreateLoad(arr_descr->get_pointer_to_data(llvm_tmp));
+        }
+
+        // // TODO: refactor this into a function, it is being used a few times
+        // llvm::Type *target_type = llvm_tmp->getType();
+        // // Create alloca to get a pointer, but do it
+        // // at the beginning of the function to avoid
+        // // using alloca inside a loop, which would
+        // // run out of stack
+        // llvm::BasicBlock &entry_block = builder->GetInsertBlock()->getParent()->getEntryBlock();
+        // llvm::IRBuilder<> builder0(context);
+        // builder0.SetInsertPoint(&entry_block, entry_block.getFirstInsertionPt());
+        // llvm::AllocaInst *target = builder0.CreateAlloca(
+        //     target_type, nullptr, "call_arg_value_ptr");
+        // builder->CreateStore(llvm_tmp, target);
+        // llvm_tmp = target;
+        return llvm_tmp;
+    }
+
+    void visit_GetPointer(const ASR::GetPointer_t& x) {
+        uint64_t ptr_loads_copy = ptr_loads;
+        ptr_loads = 0;
+        this->visit_expr(*x.m_arg);
+        ptr_loads = ptr_loads_copy;
+        tmp = GetPointerCPtrUtil(tmp);
+    }
+
+    void visit_PointerToCPtr(const ASR::PointerToCPtr_t& x) {
+        uint64_t ptr_loads_copy = ptr_loads;
+        ptr_loads = 0;
+        this->visit_expr(*x.m_arg);
+        ptr_loads = ptr_loads_copy;
+        if( !ASR::is_a<ASR::GetPointer_t>(*x.m_arg) ) {
+            tmp = GetPointerCPtrUtil(tmp);
+        }
+        tmp = builder->CreateBitCast(tmp,
+                    llvm::Type::getVoidTy(context)->getPointerTo());
+    }
+
+
     void visit_CPtrToPointer(const ASR::CPtrToPointer_t& x) {
         ASR::expr_t *cptr = x.m_cptr, *fptr = x.m_ptr, *shape = x.m_shape;
-        if( shape ) {
+        int reduce_loads = 0;
+        if( ASR::is_a<ASR::Var_t>(*cptr) ) {
+            ASR::Variable_t* cptr_var = ASRUtils::EXPR2VAR(cptr);
+            reduce_loads = cptr_var->m_intent == ASRUtils::intent_in;
+        }
+        if( ASRUtils::is_array(ASRUtils::expr_type(fptr)) ) {
             uint64_t ptr_loads_copy = ptr_loads;
-            ptr_loads = 1;
+            ptr_loads = 1 - reduce_loads;
             this->visit_expr(*cptr);
             llvm::Value* llvm_cptr = tmp;
             ptr_loads = 0;
             this->visit_expr(*fptr);
             llvm::Value* llvm_fptr = tmp;
             ptr_loads = ptr_loads_copy;
-            this->visit_expr(*shape);
-            llvm::Value* llvm_shape = tmp;
+            llvm::Value* llvm_shape = nullptr;
+            if( shape ) {
+                this->visit_expr(*shape);
+                llvm_shape = tmp;
+            }
             llvm::Type* llvm_fptr_type = llvm_fptr->getType();
             llvm_fptr_type = static_cast<llvm::PointerType*>(llvm_fptr_type)->getElementType();
             llvm_fptr_type = static_cast<llvm::PointerType*>(llvm_fptr_type)->getElementType();
@@ -2635,7 +2698,7 @@ public:
             llvm::Value* fptr_data = arr_descr->get_pointer_to_data(llvm_fptr);
             llvm::Value* fptr_des = arr_descr->get_pointer_to_dimension_descriptor_array(llvm_fptr);
             llvm::Value* shape_data = llvm_shape;
-            if( arr_descr->is_array(llvm_shape) ) {
+            if( llvm_shape && arr_descr->is_array(llvm_shape) ) {
                 shape_data = builder->CreateLoad(arr_descr->get_pointer_to_data(llvm_shape));
             }
             llvm_cptr = builder->CreateBitCast(llvm_cptr,
@@ -2649,14 +2712,14 @@ public:
                 llvm::Value* desi_size = arr_descr->get_dimension_size(fptr_des, curr_dim, false);
                 llvm::Value* i32_one = llvm::ConstantInt::get(context, llvm::APInt(32, 1));
                 llvm::Value* new_lb = i32_one;
-                llvm::Value* new_ub = builder->CreateLoad(llvm_utils->create_ptr_gep(shape_data, i));
+                llvm::Value* new_ub = shape_data ? builder->CreateLoad(llvm_utils->create_ptr_gep(shape_data, i)) : i32_one;
                 builder->CreateStore(new_lb, desi_lb);
                 builder->CreateStore(new_ub, desi_ub);
                 builder->CreateStore(builder->CreateAdd(builder->CreateSub(new_ub, new_lb), i32_one), desi_size);
             }
         } else {
             uint64_t ptr_loads_copy = ptr_loads;
-            ptr_loads = 1;
+            ptr_loads = 1 - reduce_loads;
             this->visit_expr(*cptr);
             llvm::Value* llvm_cptr = tmp;
             ptr_loads = 0;
@@ -2680,6 +2743,22 @@ public:
     void visit_Assignment(const ASR::Assignment_t &x) {
         if( x.m_overloaded ) {
             this->visit_stmt(*x.m_overloaded);
+            return ;
+        }
+
+        // TODO: Remove this check after supporting ListConstant
+        if( ASR::is_a<ASR::List_t>(*ASRUtils::expr_type(x.m_value)) ) {
+            return ;
+        }
+
+        if( ASR::is_a<ASR::Pointer_t>(*ASRUtils::expr_type(x.m_target)) &&
+            ASR::is_a<ASR::GetPointer_t>(*x.m_value) ) {
+            ASR::Variable_t *asr_target = EXPR2VAR(x.m_target);
+            ASR::GetPointer_t* get_ptr = ASR::down_cast<ASR::GetPointer_t>(x.m_value);
+            ASR::Variable_t *asr_value = EXPR2VAR(get_ptr->m_arg);
+            uint32_t value_h = get_hash((ASR::asr_t*)asr_value);
+            uint32_t target_h = get_hash((ASR::asr_t*)asr_target);
+            builder->CreateStore(llvm_symtab[value_h], llvm_symtab[target_h]);
             return ;
         }
         llvm::Value *target, *value;
@@ -2763,6 +2842,13 @@ public:
     }
 
     void visit_BlockCall(const ASR::BlockCall_t& x) {
+        if( x.m_label != -1 ) {
+            if( llvm_goto_targets.find(x.m_label) == llvm_goto_targets.end() ) {
+                llvm::BasicBlock *new_target = llvm::BasicBlock::Create(context, "goto_target");
+                llvm_goto_targets[x.m_label] = new_target;
+            }
+            start_new_block(llvm_goto_targets[x.m_label]);
+        }
         LFORTRAN_ASSERT(ASR::is_a<ASR::Block_t>(*x.m_m));
         ASR::Block_t* block = ASR::down_cast<ASR::Block_t>(x.m_m);
         declare_vars(*block);
@@ -2781,11 +2867,7 @@ public:
         }
     }
 
-    void visit_Compare(const ASR::Compare_t &x) {
-        if( x.m_overloaded ) {
-            this->visit_expr(*x.m_overloaded);
-            return ;
-        }
+    void visit_IntegerCompare(const ASR::IntegerCompare_t &x) {
         if (x.m_value) {
             this->visit_expr_wrapper(x.m_value, true);
             return;
@@ -2794,167 +2876,202 @@ public:
         llvm::Value *left = tmp;
         this->visit_expr_wrapper(x.m_right, true);
         llvm::Value *right = tmp;
-        LFORTRAN_ASSERT_MSG(expr_type(x.m_left)->type == expr_type(x.m_right)->type,
-                            ASRUtils::type_to_str(expr_type(x.m_left)) + " != " +
-                            ASRUtils::type_to_str(expr_type(x.m_right)));
-        ASR::ttypeType optype = expr_type(x.m_left)->type;
-        if (optype == ASR::ttypeType::Integer) {
-            switch (x.m_op) {
-                case (ASR::cmpopType::Eq) : {
-                    tmp = builder->CreateICmpEQ(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::Gt) : {
-                    tmp = builder->CreateICmpSGT(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::GtE) : {
-                    tmp = builder->CreateICmpSGE(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::Lt) : {
-                    tmp = builder->CreateICmpSLT(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::LtE) : {
-                    tmp = builder->CreateICmpSLE(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::NotEq) : {
-                    tmp = builder->CreateICmpNE(left, right);
-                    break;
-                }
-                default : {
-                    throw CodeGenError("Comparison operator not implemented",
-                            x.base.base.loc);
-                }
+        switch (x.m_op) {
+            case (ASR::cmpopType::Eq) : {
+                tmp = builder->CreateICmpEQ(left, right);
+                break;
             }
-        } else if (optype == ASR::ttypeType::Real) {
-            switch (x.m_op) {
-                case (ASR::cmpopType::Eq) : {
-                    tmp = builder->CreateFCmpUEQ(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::Gt) : {
-                    tmp = builder->CreateFCmpUGT(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::GtE) : {
-                    tmp = builder->CreateFCmpUGE(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::Lt) : {
-                    tmp = builder->CreateFCmpULT(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::LtE) : {
-                    tmp = builder->CreateFCmpULE(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::NotEq) : {
-                    tmp = builder->CreateFCmpUNE(left, right);
-                    break;
-                }
-                default : {
-                    throw CodeGenError("Comparison operator not implemented",
-                            x.base.base.loc);
-                }
+            case (ASR::cmpopType::Gt) : {
+                tmp = builder->CreateICmpSGT(left, right);
+                break;
             }
-        } else if (optype == ASR::ttypeType::Complex) {
-            llvm::Value* real_left = complex_re(left, left->getType());
-            llvm::Value* real_right = complex_re(right, right->getType());
-            llvm::Value* img_left = complex_im(left, left->getType());
-            llvm::Value* img_right = complex_im(right, right->getType());
-            llvm::Value *real_res, *img_res;
-            switch (x.m_op) {
-                case (ASR::cmpopType::Eq) : {
-                    real_res = builder->CreateFCmpUEQ(real_left, real_right);
-                    img_res = builder->CreateFCmpUEQ(img_left, img_right);
-                    break;
-                }
-                case (ASR::cmpopType::NotEq) : {
-                    real_res = builder->CreateFCmpUNE(real_left, real_right);
-                    img_res = builder->CreateFCmpUNE(img_left, img_right);
-                    break;
-                }
-                default : {
-                    throw CodeGenError("Comparison operator not implemented",
-                            x.base.base.loc);
-                }
+            case (ASR::cmpopType::GtE) : {
+                tmp = builder->CreateICmpSGE(left, right);
+                break;
             }
-            tmp = builder->CreateAnd(real_res, img_res);
-        } else if (optype == ASR::ttypeType::Character) {
-            // TODO: For now we only compare the first character of the strings
-            left = CreateLoad(left);
-            right = CreateLoad(right);
-            switch (x.m_op) {
-                case (ASR::cmpopType::Eq) : {
-                    tmp = builder->CreateICmpEQ(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::NotEq) : {
-                    tmp = builder->CreateICmpNE(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::Gt) : {
-                    tmp = builder->CreateICmpUGT(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::GtE) : {
-                    tmp = builder->CreateICmpUGE(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::Lt) : {
-                    tmp = builder->CreateICmpULT(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::LtE) : {
-                    tmp = builder->CreateICmpULE(left, right);
-                    break;
-                }
-                default : {
-                    throw CodeGenError("Comparison operator not implemented.",
-                            x.base.base.loc);
-                }
+            case (ASR::cmpopType::Lt) : {
+                tmp = builder->CreateICmpSLT(left, right);
+                break;
             }
-        } else if (optype == ASR::ttypeType::Logical) {
-            // i1 -> i32
-            left = builder->CreateZExt(left, llvm::Type::getInt32Ty(context));
-            right = builder->CreateZExt(right, llvm::Type::getInt32Ty(context));
-            switch (x.m_op) {
-                case (ASR::cmpopType::Eq) : {
-                    tmp = builder->CreateICmpEQ(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::NotEq) : {
-                    tmp = builder->CreateICmpNE(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::Gt) : {
-                    tmp = builder->CreateICmpUGT(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::GtE) : {
-                    tmp = builder->CreateICmpUGE(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::Lt) : {
-                    tmp = builder->CreateICmpULT(left, right);
-                    break;
-                }
-                case (ASR::cmpopType::LtE) : {
-                    tmp = builder->CreateICmpULE(left, right);
-                    break;
-                }
-                default : {
-                    throw CodeGenError("Comparison operator not implemented.",
-                            x.base.base.loc);
-                }
+            case (ASR::cmpopType::LtE) : {
+                tmp = builder->CreateICmpSLE(left, right);
+                break;
             }
-        } else {
-            throw CodeGenError("Only Integer, Real, Complex, Character, and Logical"
-                    " types are supported for comparison.", x.base.base.loc);
+            case (ASR::cmpopType::NotEq) : {
+                tmp = builder->CreateICmpNE(left, right);
+                break;
+            }
+            default : {
+                throw CodeGenError("Comparison operator not implemented",
+                        x.base.base.loc);
+            }
         }
+    }
+
+    void visit_RealCompare(const ASR::RealCompare_t &x) {
+        if (x.m_value) {
+            this->visit_expr_wrapper(x.m_value, true);
+            return;
+        }
+        this->visit_expr_wrapper(x.m_left, true);
+        llvm::Value *left = tmp;
+        this->visit_expr_wrapper(x.m_right, true);
+        llvm::Value *right = tmp;
+        switch (x.m_op) {
+            case (ASR::cmpopType::Eq) : {
+                tmp = builder->CreateFCmpUEQ(left, right);
+                break;
+            }
+            case (ASR::cmpopType::Gt) : {
+                tmp = builder->CreateFCmpUGT(left, right);
+                break;
+            }
+            case (ASR::cmpopType::GtE) : {
+                tmp = builder->CreateFCmpUGE(left, right);
+                break;
+            }
+            case (ASR::cmpopType::Lt) : {
+                tmp = builder->CreateFCmpULT(left, right);
+                break;
+            }
+            case (ASR::cmpopType::LtE) : {
+                tmp = builder->CreateFCmpULE(left, right);
+                break;
+            }
+            case (ASR::cmpopType::NotEq) : {
+                tmp = builder->CreateFCmpUNE(left, right);
+                break;
+            }
+            default : {
+                throw CodeGenError("Comparison operator not implemented",
+                        x.base.base.loc);
+            }
+        }
+    }
+
+    void visit_ComplexCompare(const ASR::ComplexCompare_t &x) {
+        if (x.m_value) {
+            this->visit_expr_wrapper(x.m_value, true);
+            return;
+        }
+        this->visit_expr_wrapper(x.m_left, true);
+        llvm::Value *left = tmp;
+        this->visit_expr_wrapper(x.m_right, true);
+        llvm::Value *right = tmp;
+        llvm::Value* real_left = complex_re(left, left->getType());
+        llvm::Value* real_right = complex_re(right, right->getType());
+        llvm::Value* img_left = complex_im(left, left->getType());
+        llvm::Value* img_right = complex_im(right, right->getType());
+        llvm::Value *real_res, *img_res;
+        switch (x.m_op) {
+            case (ASR::cmpopType::Eq) : {
+                real_res = builder->CreateFCmpUEQ(real_left, real_right);
+                img_res = builder->CreateFCmpUEQ(img_left, img_right);
+                break;
+            }
+            case (ASR::cmpopType::NotEq) : {
+                real_res = builder->CreateFCmpUNE(real_left, real_right);
+                img_res = builder->CreateFCmpUNE(img_left, img_right);
+                break;
+            }
+            default : {
+                throw CodeGenError("Comparison operator not implemented",
+                        x.base.base.loc);
+            }
+        }
+        tmp = builder->CreateAnd(real_res, img_res);
+    }
+
+    void visit_StringCompare(const ASR::StringCompare_t &x) {
+        if (x.m_value) {
+            this->visit_expr_wrapper(x.m_value, true);
+            return;
+        }
+        this->visit_expr_wrapper(x.m_left, true);
+        llvm::Value *left = tmp;
+        this->visit_expr_wrapper(x.m_right, true);
+        llvm::Value *right = tmp;
+        // TODO: For now we only compare the first character of the strings
+        left = CreateLoad(left);
+        right = CreateLoad(right);
+        switch (x.m_op) {
+            case (ASR::cmpopType::Eq) : {
+                tmp = builder->CreateICmpEQ(left, right);
+                break;
+            }
+            case (ASR::cmpopType::NotEq) : {
+                tmp = builder->CreateICmpNE(left, right);
+                break;
+            }
+            case (ASR::cmpopType::Gt) : {
+                tmp = builder->CreateICmpUGT(left, right);
+                break;
+            }
+            case (ASR::cmpopType::GtE) : {
+                tmp = builder->CreateICmpUGE(left, right);
+                break;
+            }
+            case (ASR::cmpopType::Lt) : {
+                tmp = builder->CreateICmpULT(left, right);
+                break;
+            }
+            case (ASR::cmpopType::LtE) : {
+                tmp = builder->CreateICmpULE(left, right);
+                break;
+            }
+            default : {
+                throw CodeGenError("Comparison operator not implemented",
+                        x.base.base.loc);
+            }
+        }
+    }
+
+    void visit_LogicalCompare(const ASR::LogicalCompare_t &x) {
+        if (x.m_value) {
+            this->visit_expr_wrapper(x.m_value, true);
+            return;
+        }
+        this->visit_expr_wrapper(x.m_left, true);
+        llvm::Value *left = tmp;
+        this->visit_expr_wrapper(x.m_right, true);
+        llvm::Value *right = tmp;
+        // i1 -> i32
+        left = builder->CreateZExt(left, llvm::Type::getInt32Ty(context));
+        right = builder->CreateZExt(right, llvm::Type::getInt32Ty(context));
+        switch (x.m_op) {
+            case (ASR::cmpopType::Eq) : {
+                tmp = builder->CreateICmpEQ(left, right);
+                break;
+            }
+            case (ASR::cmpopType::NotEq) : {
+                tmp = builder->CreateICmpNE(left, right);
+                break;
+            }
+            case (ASR::cmpopType::Gt) : {
+                tmp = builder->CreateICmpUGT(left, right);
+                break;
+            }
+            case (ASR::cmpopType::GtE) : {
+                tmp = builder->CreateICmpUGE(left, right);
+                break;
+            }
+            case (ASR::cmpopType::Lt) : {
+                tmp = builder->CreateICmpULT(left, right);
+                break;
+            }
+            case (ASR::cmpopType::LtE) : {
+                tmp = builder->CreateICmpULE(left, right);
+                break;
+            }
+            default : {
+                throw CodeGenError("Comparison operator not implemented",
+                        x.base.base.loc);
+            }
+        }
+    }
+
+    void visit_OverloadedCompare(const ASR::OverloadedCompare_t &x) {
+        this->visit_expr(*x.m_overloaded);
     }
 
     void visit_If(const ASR::If_t &x) {
@@ -3043,7 +3160,7 @@ public:
         start_new_block(target);
     }
 
-    void visit_BoolOp(const ASR::BoolOp_t &x) {
+    void visit_LogicalBinOp(const ASR::LogicalBinOp_t &x) {
         if (x.m_value) {
             this->visit_expr_wrapper(x.m_value, true);
             return;
@@ -3052,31 +3169,28 @@ public:
         llvm::Value *left_val = tmp;
         this->visit_expr_wrapper(x.m_right, true);
         llvm::Value *right_val = tmp;
-        if (x.m_type->type == ASR::ttypeType::Logical) {
-            switch (x.m_op) {
-                case ASR::boolopType::And: {
-                    tmp = builder->CreateAnd(left_val, right_val);
-                    break;
-                };
-                case ASR::boolopType::Or: {
-                    tmp = builder->CreateOr(left_val, right_val);
-                    break;
-                };
-                case ASR::boolopType::Xor: {
-                    tmp = builder->CreateXor(left_val, right_val);
-                    break;
-                };
-                case ASR::boolopType::NEqv: {
-                    tmp = builder->CreateXor(left_val, right_val);
-                    break;
-                };
-                case ASR::boolopType::Eqv: {
-                    tmp = builder->CreateXor(left_val, right_val);
-                    tmp = builder->CreateNot(tmp);
-                };
-            }
-        } else {
-            throw CodeGenError("Boolop: Only Logical types can be used with logical operators.");
+        LFORTRAN_ASSERT(ASRUtils::is_logical(*x.m_type))
+        switch (x.m_op) {
+            case ASR::logicalbinopType::And: {
+                tmp = builder->CreateAnd(left_val, right_val);
+                break;
+            };
+            case ASR::logicalbinopType::Or: {
+                tmp = builder->CreateOr(left_val, right_val);
+                break;
+            };
+            case ASR::logicalbinopType::Xor: {
+                tmp = builder->CreateXor(left_val, right_val);
+                break;
+            };
+            case ASR::logicalbinopType::NEqv: {
+                tmp = builder->CreateXor(left_val, right_val);
+                break;
+            };
+            case ASR::logicalbinopType::Eqv: {
+                tmp = builder->CreateXor(left_val, right_val);
+                tmp = builder->CreateNot(tmp);
+            };
         }
     }
 
@@ -3141,12 +3255,7 @@ public:
         tmp = lfortran_str_copy(str, left, right);
     }
 
-
-    void visit_BinOp(const ASR::BinOp_t &x) {
-        if( x.m_overloaded ) {
-            this->visit_expr(*x.m_overloaded);
-            return ;
-        }
+    void visit_IntegerBinOp(const ASR::IntegerBinOp_t &x) {
         if (x.m_value) {
             this->visit_expr_wrapper(x.m_value, true);
             return;
@@ -3155,193 +3264,193 @@ public:
         llvm::Value *left_val = tmp;
         this->visit_expr_wrapper(x.m_right, true);
         llvm::Value *right_val = tmp;
-        if (ASRUtils::is_integer(*x.m_type)) {
-            switch (x.m_op) {
-                case ASR::binopType::Add: {
-                    tmp = builder->CreateAdd(left_val, right_val);
-                    break;
-                };
-                case ASR::binopType::Sub: {
-                    tmp = builder->CreateSub(left_val, right_val);
-                    break;
-                };
-                case ASR::binopType::Mul: {
-                    tmp = builder->CreateMul(left_val, right_val);
-                    break;
-                };
-                case ASR::binopType::Div: {
-                    tmp = builder->CreateUDiv(left_val, right_val);
-                    break;
-                };
-                case ASR::binopType::Pow: {
-                    llvm::Type *type;
-                    int a_kind;
-                    a_kind = down_cast<ASR::Integer_t>(ASRUtils::type_get_past_pointer(x.m_type))->m_kind;
-                    type = getFPType(a_kind);
-                    llvm::Value *fleft = builder->CreateSIToFP(left_val,
-                            type);
-                    llvm::Value *fright = builder->CreateSIToFP(right_val,
-                            type);
-                    std::string func_name = a_kind == 4 ? "llvm.pow.f32" : "llvm.pow.f64";
-                    llvm::Function *fn_pow = module->getFunction(func_name);
-                    if (!fn_pow) {
-                        llvm::FunctionType *function_type = llvm::FunctionType::get(
-                                type, { type, type}, false);
-                        fn_pow = llvm::Function::Create(function_type,
-                                llvm::Function::ExternalLinkage, func_name,
-                                module.get());
-                    }
-                    tmp = builder->CreateCall(fn_pow, {fleft, fright});
-                    type = getIntType(a_kind);
-                    tmp = builder->CreateFPToSI(tmp, type);
-                    break;
-                };
+        LFORTRAN_ASSERT(ASRUtils::is_integer(*x.m_type))
+        switch (x.m_op) {
+            case ASR::binopType::Add: {
+                tmp = builder->CreateAdd(left_val, right_val);
+                break;
+            };
+            case ASR::binopType::Sub: {
+                tmp = builder->CreateSub(left_val, right_val);
+                break;
+            };
+            case ASR::binopType::Mul: {
+                tmp = builder->CreateMul(left_val, right_val);
+                break;
+            };
+            case ASR::binopType::Div: {
+                tmp = builder->CreateUDiv(left_val, right_val);
+                break;
+            };
+            case ASR::binopType::Pow: {
+                llvm::Type *type;
+                int a_kind;
+                a_kind = down_cast<ASR::Integer_t>(ASRUtils::type_get_past_pointer(x.m_type))->m_kind;
+                type = getFPType(a_kind);
+                llvm::Value *fleft = builder->CreateSIToFP(left_val,
+                        type);
+                llvm::Value *fright = builder->CreateSIToFP(right_val,
+                        type);
+                std::string func_name = a_kind == 4 ? "llvm.pow.f32" : "llvm.pow.f64";
+                llvm::Function *fn_pow = module->getFunction(func_name);
+                if (!fn_pow) {
+                    llvm::FunctionType *function_type = llvm::FunctionType::get(
+                            type, { type, type}, false);
+                    fn_pow = llvm::Function::Create(function_type,
+                            llvm::Function::ExternalLinkage, func_name,
+                            module.get());
+                }
+                tmp = builder->CreateCall(fn_pow, {fleft, fright});
+                type = getIntType(a_kind);
+                tmp = builder->CreateFPToSI(tmp, type);
+                break;
+            };
+            case ASR::binopType::BitOr: {
+                tmp = builder->CreateOr(left_val, right_val);
+                break;
             }
-        } else if (ASRUtils::is_real(*x.m_type)) {
-            switch (x.m_op) {
-                case ASR::binopType::Add: {
-                    tmp = builder->CreateFAdd(left_val, right_val);
-                    break;
-                };
-                case ASR::binopType::Sub: {
-                    tmp = builder->CreateFSub(left_val, right_val);
-                    break;
-                };
-                case ASR::binopType::Mul: {
-                    tmp = builder->CreateFMul(left_val, right_val);
-                    break;
-                };
-                case ASR::binopType::Div: {
-                    tmp = builder->CreateFDiv(left_val, right_val);
-                    break;
-                };
-                case ASR::binopType::Pow: {
-                    llvm::Type *type;
-                    int a_kind;
-                    a_kind = down_cast<ASR::Real_t>(ASRUtils::type_get_past_pointer(x.m_type))->m_kind;
-                    type = getFPType(a_kind);
-                    std::string func_name = a_kind == 4 ? "llvm.pow.f32" : "llvm.pow.f64";
-                    llvm::Function *fn_pow = module->getFunction(func_name);
-                    if (!fn_pow) {
-                        llvm::FunctionType *function_type = llvm::FunctionType::get(
-                                type, { type, type }, false);
-                        fn_pow = llvm::Function::Create(function_type,
-                                llvm::Function::ExternalLinkage, func_name,
-                                module.get());
-                    }
-                    tmp = builder->CreateCall(fn_pow, {left_val, right_val});
-                    break;
-                };
+            case ASR::binopType::BitAnd: {
+                tmp = builder->CreateAnd(left_val, right_val);
+                break;
             }
-        } else if (ASRUtils::is_complex(*x.m_type)) {
-            llvm::Type *type;
-            int a_kind;
-            a_kind = down_cast<ASR::Complex_t>(ASRUtils::type_get_past_pointer(x.m_type))->m_kind;
-            type = getComplexType(a_kind);
-            if( left_val->getType()->isPointerTy() ) {
-                left_val = CreateLoad(left_val);
+            case ASR::binopType::BitXor: {
+                tmp = builder->CreateXor(left_val, right_val);
+                break;
             }
-            if( right_val->getType()->isPointerTy() ) {
-                right_val = CreateLoad(right_val);
+            case ASR::binopType::BitLShift: {
+                tmp = builder->CreateShl(left_val, right_val);
+                break;
             }
-            std::string fn_name;
-            switch (x.m_op) {
-                case ASR::binopType::Add: {
-                    if (a_kind == 4) {
-                        fn_name = "_lfortran_complex_add_32";
-                    } else {
-                        fn_name = "_lfortran_complex_add_64";
-                    }
-                    break;
-                };
-                case ASR::binopType::Sub: {
-                    if (a_kind == 4) {
-                        fn_name = "_lfortran_complex_sub_32";
-                    } else {
-                        fn_name = "_lfortran_complex_sub_64";
-                    }
-                    break;
-                };
-                case ASR::binopType::Mul: {
-                    if (a_kind == 4) {
-                        fn_name = "_lfortran_complex_mul_32";
-                    } else {
-                        fn_name = "_lfortran_complex_mul_64";
-                    }
-                    break;
-                };
-                case ASR::binopType::Div: {
-                    if (a_kind == 4) {
-                        fn_name = "_lfortran_complex_div_32";
-                    } else {
-                        fn_name = "_lfortran_complex_div_64";
-                    }
-                    break;
-                };
-                case ASR::binopType::Pow: {
-                    if (a_kind == 4) {
-                        fn_name = "_lfortran_complex_pow_32";
-                    } else {
-                        fn_name = "_lfortran_complex_pow_64";
-                    }
-                    break;
-                };
+            case ASR::binopType::BitRShift: {
+                tmp = builder->CreateAShr(left_val, right_val);
+                break;
             }
-            tmp = lfortran_complex_bin_op(left_val, right_val, fn_name, type);
-        } else {
-            throw CodeGenError("Binop: Only Real, Integer and Complex types are allowed");
         }
     }
 
-    void visit_UnaryOp(const ASR::UnaryOp_t &x) {
+    void visit_RealBinOp(const ASR::RealBinOp_t &x) {
         if (x.m_value) {
             this->visit_expr_wrapper(x.m_value, true);
             return;
         }
-        this->visit_expr_wrapper(x.m_operand, true);
-        if (x.m_type->type == ASR::ttypeType::Integer) {
-            if (x.m_op == ASR::unaryopType::UAdd) {
-                // tmp = tmp;
-                return;
-            } else if (x.m_op == ASR::unaryopType::USub) {
-                llvm::Value *zero = llvm::ConstantInt::get(context,
-                    llvm::APInt(ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(x.m_operand)) * 8, 0));
-                tmp = builder ->CreateSub(zero, tmp);
-                return;
-            } else {
-                throw CodeGenError("Unary type not implemented yet");
-            }
-        } else if (x.m_type->type == ASR::ttypeType::Real) {
-            if (x.m_op == ASR::unaryopType::UAdd) {
-                // tmp = tmp;
-                return;
-            } else if (x.m_op == ASR::unaryopType::USub) {
-                llvm::Value *zero;
-                int a_kind = down_cast<ASR::Real_t>(x.m_type)->m_kind;
-                if (a_kind == 4) {
-                    zero = llvm::ConstantFP::get(context,
-                            llvm::APFloat((float)0.0));
-                } else if (a_kind == 8) {
-                    zero = llvm::ConstantFP::get(context,
-                            llvm::APFloat((double)0.0));
-                } else {
-                    throw CodeGenError("Unary type kind not implemented yet, only 4 and 8 is");
+        this->visit_expr_wrapper(x.m_left, true);
+        llvm::Value *left_val = tmp;
+        this->visit_expr_wrapper(x.m_right, true);
+        llvm::Value *right_val = tmp;
+        LFORTRAN_ASSERT(ASRUtils::is_real(*x.m_type))
+        switch (x.m_op) {
+            case ASR::binopType::Add: {
+                tmp = builder->CreateFAdd(left_val, right_val);
+                break;
+            };
+            case ASR::binopType::Sub: {
+                tmp = builder->CreateFSub(left_val, right_val);
+                break;
+            };
+            case ASR::binopType::Mul: {
+                tmp = builder->CreateFMul(left_val, right_val);
+                break;
+            };
+            case ASR::binopType::Div: {
+                tmp = builder->CreateFDiv(left_val, right_val);
+                break;
+            };
+            case ASR::binopType::Pow: {
+                llvm::Type *type;
+                int a_kind;
+                a_kind = down_cast<ASR::Real_t>(ASRUtils::type_get_past_pointer(x.m_type))->m_kind;
+                type = getFPType(a_kind);
+                std::string func_name = a_kind == 4 ? "llvm.pow.f32" : "llvm.pow.f64";
+                llvm::Function *fn_pow = module->getFunction(func_name);
+                if (!fn_pow) {
+                    llvm::FunctionType *function_type = llvm::FunctionType::get(
+                            type, { type, type }, false);
+                    fn_pow = llvm::Function::Create(function_type,
+                            llvm::Function::ExternalLinkage, func_name,
+                            module.get());
                 }
-                tmp = builder ->CreateFSub(zero, tmp);
-                return;
-            } else {
-                throw CodeGenError("Unary type not implemented yet");
+                tmp = builder->CreateCall(fn_pow, {left_val, right_val});
+                break;
+            };
+            default: {
+                throw CodeGenError("Binary operator '" + ASRUtils::binop_to_str_python(x.m_op) + "' not supported",
+                    x.base.base.loc);
             }
-        } else if (x.m_type->type == ASR::ttypeType::Logical) {
-            if (x.m_op == ASR::unaryopType::Not) {
-                tmp = builder ->CreateNot(tmp);
-                return;
-            } else {
-                throw CodeGenError("Unary type not implemented yet in Logical");
-            }
-        } else {
-            throw CodeGenError("UnaryOp: type not supported yet");
         }
+    }
+
+    void visit_ComplexBinOp(const ASR::ComplexBinOp_t &x) {
+        if (x.m_value) {
+            this->visit_expr_wrapper(x.m_value, true);
+            return;
+        }
+        this->visit_expr_wrapper(x.m_left, true);
+        llvm::Value *left_val = tmp;
+        this->visit_expr_wrapper(x.m_right, true);
+        llvm::Value *right_val = tmp;
+        LFORTRAN_ASSERT(ASRUtils::is_complex(*x.m_type));
+        llvm::Type *type;
+        int a_kind;
+        a_kind = down_cast<ASR::Complex_t>(ASRUtils::type_get_past_pointer(x.m_type))->m_kind;
+        type = getComplexType(a_kind);
+        if( left_val->getType()->isPointerTy() ) {
+            left_val = CreateLoad(left_val);
+        }
+        if( right_val->getType()->isPointerTy() ) {
+            right_val = CreateLoad(right_val);
+        }
+        std::string fn_name;
+        switch (x.m_op) {
+            case ASR::binopType::Add: {
+                if (a_kind == 4) {
+                    fn_name = "_lfortran_complex_add_32";
+                } else {
+                    fn_name = "_lfortran_complex_add_64";
+                }
+                break;
+            };
+            case ASR::binopType::Sub: {
+                if (a_kind == 4) {
+                    fn_name = "_lfortran_complex_sub_32";
+                } else {
+                    fn_name = "_lfortran_complex_sub_64";
+                }
+                break;
+            };
+            case ASR::binopType::Mul: {
+                if (a_kind == 4) {
+                    fn_name = "_lfortran_complex_mul_32";
+                } else {
+                    fn_name = "_lfortran_complex_mul_64";
+                }
+                break;
+            };
+            case ASR::binopType::Div: {
+                if (a_kind == 4) {
+                    fn_name = "_lfortran_complex_div_32";
+                } else {
+                    fn_name = "_lfortran_complex_div_64";
+                }
+                break;
+            };
+            case ASR::binopType::Pow: {
+                if (a_kind == 4) {
+                    fn_name = "_lfortran_complex_pow_32";
+                } else {
+                    fn_name = "_lfortran_complex_pow_64";
+                }
+                break;
+            };
+            default: {
+                throw CodeGenError("Binary operator '" + ASRUtils::binop_to_str_python(x.m_op) + "' not supported",
+                    x.base.base.loc);
+            }
+        }
+        tmp = lfortran_complex_bin_op(left_val, right_val, fn_name, type);
+    }
+
+    void visit_OverloadedBinOp(const ASR::OverloadedBinOp_t &x) {
+        this->visit_expr(*x.m_overloaded);
     }
 
     void visit_IntegerBitNot(const ASR::IntegerBitNot_t &x) {
@@ -3660,7 +3769,11 @@ public:
         if( arr_descr->is_array(x_v) ) {
             tmp = x_v;
         } else {
-            tmp = CreateLoad(x_v);
+            tmp = x_v;
+            // Load only once since its a value
+            if( ptr_loads > 0 ) {
+                tmp = CreateLoad(tmp);
+            }
         }
     }
 
@@ -3675,13 +3788,17 @@ public:
                 switch (t2->type) {
                     case ASR::ttypeType::Integer:
                     case ASR::ttypeType::Real:
-                    case ASR::ttypeType::Complex: {
+                    case ASR::ttypeType::Complex:
+                    case ASR::ttypeType::Derived: {
+                        if( t2->type == ASR::ttypeType::Derived ) {
+                            ASR::Derived_t* d = ASR::down_cast<ASR::Derived_t>(t2);
+                            der_type_name = ASRUtils::symbol_name(d->m_derived_type);
+                        }
                         fetch_ptr(x);
                         break;
                     }
                     case ASR::ttypeType::Character:
-                    case ASR::ttypeType::Logical:
-                    case ASR::ttypeType::Derived: {
+                    case ASR::ttypeType::Logical: {
                         break;
                     }
                     default:
@@ -3889,7 +4006,61 @@ public:
                 break;
             }
             case (ASR::cast_kindType::IntegerToLogical) : {
-                tmp = builder->CreateICmpNE(tmp, builder->getInt32(0));
+                ASR::ttype_t* curr_type = extract_ttype_t_from_expr(x.m_arg);
+                LFORTRAN_ASSERT(curr_type != nullptr)
+                int a_kind = ASRUtils::extract_kind_from_ttype_t(curr_type);
+                switch (a_kind) {
+                    case 1:
+                        tmp = builder->CreateICmpNE(tmp, builder->getInt8(0));
+                        break;
+                    case 2:
+                        tmp = builder->CreateICmpNE(tmp, builder->getInt16(0));
+                        break;
+                    case 4:
+                        tmp = builder->CreateICmpNE(tmp, builder->getInt32(0));
+                        break;
+                    case 8:
+                        tmp = builder->CreateICmpNE(tmp, builder->getInt64(0));
+                        break;
+                }
+                break;
+            }
+            case (ASR::cast_kindType::RealToLogical) : {
+                llvm::Value *zero;
+                ASR::ttype_t* curr_type = extract_ttype_t_from_expr(x.m_arg);
+                LFORTRAN_ASSERT(curr_type != nullptr)
+                int a_kind = ASRUtils::extract_kind_from_ttype_t(curr_type);
+                if (a_kind == 4) {
+                    zero = llvm::ConstantFP::get(context, llvm::APFloat((float)0.0));
+                } else {
+                    zero = llvm::ConstantFP::get(context, llvm::APFloat(0.0));
+                }
+                tmp = builder->CreateFCmpUNE(tmp, zero);
+                break;
+            }
+            case (ASR::cast_kindType::CharacterToLogical) : {
+                llvm::AllocaInst *parg = builder->CreateAlloca(character_type, nullptr);
+                builder->CreateStore(tmp, parg);
+                tmp = builder->CreateICmpNE(lfortran_str_len(parg), builder->getInt32(0));
+                break;
+            }
+            case (ASR::cast_kindType::ComplexToLogical) : {
+                // !(c.real == 0.0 && c.imag == 0.0)
+                llvm::Value *zero;
+                ASR::ttype_t* curr_type = extract_ttype_t_from_expr(x.m_arg);
+                LFORTRAN_ASSERT(curr_type != nullptr)
+                int a_kind = ASRUtils::extract_kind_from_ttype_t(curr_type);
+                if (a_kind == 4) {
+                    zero = llvm::ConstantFP::get(context, llvm::APFloat((float)0.0));
+                } else {
+                    zero = llvm::ConstantFP::get(context, llvm::APFloat(0.0));
+                }
+                llvm::Value *c_real = complex_re(tmp, tmp->getType());
+                llvm::Value *real_check = builder->CreateFCmpUEQ(c_real, zero);
+                llvm::Value *c_imag = complex_im(tmp, tmp->getType());
+                llvm::Value *imag_check = builder->CreateFCmpUEQ(c_imag, zero);
+                tmp = builder->CreateAnd(real_check, imag_check);
+                tmp = builder->CreateNot(tmp);
                 break;
             }
             case (ASR::cast_kindType::LogicalToInteger) : {
@@ -4064,12 +4235,58 @@ public:
     void handle_print(const T &x) {
         std::vector<llvm::Value *> args;
         std::vector<std::string> fmt;
+        llvm::Value *sep = nullptr;
+        llvm::Value *end = nullptr;
+        if (x.m_separator) {
+            this->visit_expr_wrapper(x.m_separator, true);
+            sep = tmp;
+        } else {
+            sep = builder->CreateGlobalStringPtr(" ");
+        }
+        if (x.m_end) {
+            this->visit_expr_wrapper(x.m_end, true);
+            end = tmp;
+        } else {
+            end = builder->CreateGlobalStringPtr("\n");
+        }
         for (size_t i=0; i<x.n_values; i++) {
+            uint64_t ptr_loads_copy = ptr_loads;
+            int reduce_loads = 0;
+            ptr_loads = 2;
+            if( ASR::is_a<ASR::Var_t>(*x.m_values[i]) ) {
+                ASR::Variable_t* var = ASRUtils::EXPR2VAR(x.m_values[i]);
+                reduce_loads = var->m_intent == ASRUtils::intent_in;
+                if( ASR::is_a<ASR::Pointer_t>(*var->m_type) ) {
+                    ptr_loads = 1;
+                }
+            }
+            if (i != 0) {
+                fmt.push_back("%s");
+                args.push_back(sep);
+            }
+            ptr_loads = ptr_loads - reduce_loads;
             this->visit_expr_wrapper(x.m_values[i], true);
+            ptr_loads = ptr_loads_copy;
             ASR::expr_t *v = x.m_values[i];
             ASR::ttype_t *t = expr_type(v);
             int a_kind = ASRUtils::extract_kind_from_ttype_t(t);
-            if (ASRUtils::is_integer(*t) ||
+            if( ASR::is_a<ASR::Pointer_t>(*t) && ASR::is_a<ASR::Var_t>(*v) ) {
+                if( ASRUtils::is_array(ASRUtils::type_get_past_pointer(t)) ) {
+                    tmp = builder->CreateLoad(arr_descr->get_pointer_to_data(tmp));
+                }
+                fmt.push_back("%lld");
+                llvm::Value* d = builder->CreatePtrToInt(tmp, getIntType(8, false));
+                args.push_back(d);
+                continue;
+            }
+            if (t->type == ASR::ttypeType::CPtr ||
+                (t->type == ASR::ttypeType::Pointer &&
+                (ASR::is_a<ASR::Var_t>(*v) || ASR::is_a<ASR::GetPointer_t>(*v)))
+               ) {
+                fmt.push_back("%lld");
+                llvm::Value* d = builder->CreatePtrToInt(tmp, getIntType(8, false));
+                args.push_back(d);
+            } else if (ASRUtils::is_integer(*t) ||
                 ASR::is_a<ASR::Logical_t>(*ASRUtils::type_get_past_pointer(t))) {
                 switch( a_kind ) {
                     case 1 : {
@@ -4162,12 +4379,12 @@ public:
                     ASRUtils::type_to_str(t));
             }
         }
+        fmt.push_back("%s");
+        args.push_back(end);
         std::string fmt_str;
         for (size_t i=0; i<fmt.size(); i++) {
             fmt_str += fmt[i];
-            if (i < fmt.size()-1) fmt_str += " ";
         }
-        fmt_str += "\n";
         llvm::Value *fmt_ptr = builder->CreateGlobalStringPtr(fmt_str);
         std::vector<llvm::Value *> printf_args;
         printf_args.push_back(fmt_ptr);
@@ -4202,11 +4419,13 @@ public:
     template <typename T>
     inline void set_func_subrout_params(T* func_subrout, ASR::abiType& x_abi,
                                         std::uint32_t& m_h, ASR::Variable_t*& orig_arg,
-                                        std::string& orig_arg_name, size_t arg_idx) {
+                                        std::string& orig_arg_name, ASR::intentType& arg_intent,
+                                        size_t arg_idx) {
         m_h = get_hash((ASR::asr_t*)func_subrout);
         orig_arg = EXPR2VAR(func_subrout->m_args[arg_idx]);
         orig_arg_name = orig_arg->m_name;
         x_abi = func_subrout->m_abi;
+        arg_intent = orig_arg->m_intent;
     }
 
 
@@ -4222,6 +4441,7 @@ public:
             ASR::Subroutine_t* sub = down_cast<ASR::Subroutine_t>(func_subrout);
             x_abi = sub->m_abi;
         }
+        // TODO: Below if check is dead. Remove.
         if( x_abi == ASR::abiType::Intrinsic ) {
             if( name == "lbound" || name == "ubound" ) {
                 ASR::Variable_t *arg = EXPR2VAR(x.m_args[0].m_value);
@@ -4250,23 +4470,24 @@ public:
                             tmp = llvm_symtab[h];
                             func_subrout = symbol_get_past_external(x.m_name);
                             x_abi = (ASR::abiType) 0;
+                            ASR::intentType orig_arg_intent = ASR::intentType::Unspecified;
                             std::uint32_t m_h;
                             ASR::Variable_t *orig_arg = nullptr;
                             std::string orig_arg_name = "";
                             if( func_subrout->type == ASR::symbolType::Function ) {
                                 ASR::Function_t* func = down_cast<ASR::Function_t>(func_subrout);
-                                set_func_subrout_params(func, x_abi, m_h, orig_arg, orig_arg_name, i);
+                                set_func_subrout_params(func, x_abi, m_h, orig_arg, orig_arg_name, orig_arg_intent, i);
                             } else if( func_subrout->type == ASR::symbolType::Subroutine ) {
                                 ASR::Subroutine_t* sub = down_cast<ASR::Subroutine_t>(func_subrout);
-                                set_func_subrout_params(sub, x_abi, m_h, orig_arg, orig_arg_name, i);
+                                set_func_subrout_params(sub, x_abi, m_h, orig_arg, orig_arg_name, orig_arg_intent, i);
                             } else if( func_subrout->type == ASR::symbolType::ClassProcedure ) {
                                 ASR::ClassProcedure_t* clss_proc = ASR::down_cast<ASR::ClassProcedure_t>(func_subrout);
                                 if( clss_proc->m_proc->type == ASR::symbolType::Subroutine ) {
                                     ASR::Subroutine_t* sub = down_cast<ASR::Subroutine_t>(clss_proc->m_proc);
-                                    set_func_subrout_params(sub, x_abi, m_h, orig_arg, orig_arg_name, i);
+                                    set_func_subrout_params(sub, x_abi, m_h, orig_arg, orig_arg_name, orig_arg_intent, i);
                                 } else if( clss_proc->m_proc->type == ASR::symbolType::Function ) {
                                     ASR::Function_t* func = down_cast<ASR::Function_t>(clss_proc->m_proc);
-                                    set_func_subrout_params(func, x_abi, m_h, orig_arg, orig_arg_name, i);
+                                    set_func_subrout_params(func, x_abi, m_h, orig_arg, orig_arg_name, orig_arg_intent, i);
                                 }
                             } else {
                                 LFORTRAN_ASSERT(false)
@@ -4323,7 +4544,12 @@ public:
                                                     }
                                                 }
                                             } else if (is_a<ASR::CPtr_t>(*arg_type)) {
-                                                // pass
+                                                if (arg->m_intent == intent_local) {
+                                                    // Local variable of type
+                                                    // CPtr is a void**, so we
+                                                    // have to load it
+                                                    tmp = CreateLoad(tmp);
+                                                }
                                             } else {
                                                 if (!arg->m_value_attr) {
                                                     // Dereference the pointer argument (unless it is a CPtr)
@@ -4607,6 +4833,35 @@ public:
         pop_nested_stack(s);
     }
 
+    void handle_bitwise_args(const ASR::FunctionCall_t& x, llvm::Value*& arg1,
+                             llvm::Value*& arg2) {
+        LFORTRAN_ASSERT(x.n_args == 2);
+        tmp = nullptr;
+        this->visit_expr_wrapper(x.m_args[0].m_value, true);
+        arg1 = tmp;
+        tmp = nullptr;
+        this->visit_expr_wrapper(x.m_args[1].m_value, true);
+        arg2 = tmp;
+    }
+
+    void handle_bitwise_xor(const ASR::FunctionCall_t& x) {
+        llvm::Value *arg1 = nullptr, *arg2 = nullptr;
+        handle_bitwise_args(x, arg1, arg2);
+        tmp = builder->CreateXor(arg1, arg2);
+    }
+
+    void handle_bitwise_and(const ASR::FunctionCall_t& x) {
+        llvm::Value *arg1 = nullptr, *arg2 = nullptr;
+        handle_bitwise_args(x, arg1, arg2);
+        tmp = builder->CreateAnd(arg1, arg2);
+    }
+
+    void handle_bitwise_or(const ASR::FunctionCall_t& x) {
+        llvm::Value *arg1 = nullptr, *arg2 = nullptr;
+        handle_bitwise_args(x, arg1, arg2);
+        tmp = builder->CreateOr(arg1, arg2);
+    }
+
     void visit_FunctionCall(const ASR::FunctionCall_t &x) {
         if( ASRUtils::is_intrinsic_optimization(x.m_name) ) {
             ASR::Function_t* routine = ASR::down_cast<ASR::Function_t>(
@@ -4636,6 +4891,21 @@ public:
         }
         if( s == nullptr ) {
             s = ASR::down_cast<ASR::Function_t>(symbol_get_past_external(x.m_name));
+        }
+        if( ASRUtils::is_intrinsic_function2(s) ) {
+            std::string symbol_name = ASRUtils::symbol_name(x.m_name);
+            if( startswith(symbol_name, "_bitwise_xor") ) {
+                handle_bitwise_xor(x);
+                return ;
+            }
+            if( startswith(symbol_name, "_bitwise_and") ) {
+                handle_bitwise_and(x);
+                return ;
+            }
+            if( startswith(symbol_name, "_bitwise_or") ) {
+                handle_bitwise_or(x);
+                return ;
+            }
         }
         if (parent_function){
             push_nested_stack(parent_function);
@@ -4757,7 +5027,7 @@ public:
         }
         int output_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
         uint64_t ptr_loads_copy = ptr_loads;
-        ptr_loads = ptr_loads_copy -
+        ptr_loads = 2 - // Sync: instead of 2 - , should this be ptr_loads_copy -
                     (ASRUtils::expr_type(x.m_v)->type ==
                      ASR::ttypeType::Pointer);
         visit_expr_wrapper(x.m_v);
@@ -4824,7 +5094,7 @@ public:
             return ;
         }
         uint64_t ptr_loads_copy = ptr_loads;
-        ptr_loads = ptr_loads_copy -
+        ptr_loads = 2 - // Sync: instead of 2 - , should this be ptr_loads_copy -
                     (ASRUtils::expr_type(x.m_v)->type ==
                      ASR::ttypeType::Pointer);
         visit_expr_wrapper(x.m_v);
@@ -4851,42 +5121,15 @@ public:
 
 Result<std::unique_ptr<LLVMModule>> asr_to_llvm(ASR::TranslationUnit_t &asr,
         diag::Diagnostics &diagnostics,
-        llvm::LLVMContext &context, Allocator &al, Platform platform,
-        bool fast, const std::string &rl_path, const std::string &run_fn)
+        llvm::LLVMContext &context, Allocator &al,
+        LCompilers::PassManager& pass_manager,
+        Platform platform, const std::string &run_fn)
 {
     ASRToLLVMVisitor v(al, context, platform, diagnostics);
-    pass_wrap_global_stmts_into_function(al, asr, run_fn);
-
-    pass_replace_class_constructor(al, asr);
-    pass_replace_implied_do_loops(al, asr, rl_path);
-    pass_replace_arr_slice(al, asr, rl_path);
-    pass_replace_array_op(al, asr, rl_path);
-    pass_replace_print_arr(al, asr, rl_path);
-
-    if( fast ) {
-        pass_loop_unroll(al, asr, rl_path);
-    }
-
-    pass_replace_do_loops(al, asr);
-    pass_replace_forall(al, asr);
-
-    if( fast ) {
-        pass_dead_code_removal(al, asr, rl_path);
-    }
-
-    pass_replace_select_case(al, asr);
-    pass_unused_functions(al, asr);
-
-    if( fast ) {
-        pass_replace_flip_sign(al, asr, rl_path);
-        pass_replace_sign_from_value(al, asr, rl_path);
-        pass_replace_div_to_mul(al, asr, rl_path);
-        pass_replace_fma(al, asr, rl_path);
-        pass_inline_function_calls(al, asr, rl_path);
-    }
+    pass_manager.apply_passes(al, &asr, run_fn, false);
 
     // Uncomment for debugging the ASR after the transformation
-    //std::cout << pickle(asr, true, true, true) << std::endl;
+    // std::cout << pickle(asr, true, true, true) << std::endl;
 
     v.nested_func_types = pass_find_nested_vars(asr, context,
         v.nested_globals, v.nested_call_out, v.nesting_map);

--- a/src/libasr/codegen/asr_to_llvm.h
+++ b/src/libasr/codegen/asr_to_llvm.h
@@ -3,13 +3,16 @@
 
 #include <libasr/asr.h>
 #include <libasr/codegen/evaluator.h>
+#include <libasr/pass/pass_manager.h>
 
 namespace LFortran {
 
     Result<std::unique_ptr<LLVMModule>> asr_to_llvm(ASR::TranslationUnit_t &asr,
             diag::Diagnostics &diagnostics,
-            llvm::LLVMContext &context, Allocator &al, Platform platform,
-            bool fast, const std::string &rl_path, const std::string &run_fn);
+            llvm::LLVMContext &context, Allocator &al,
+            LCompilers::PassManager& pass_manager,
+            Platform platform,
+            const std::string &run_fn);
 
 } // namespace LFortran
 

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -17,6 +17,11 @@ namespace LFortran {
 
 namespace {
 
+    // This exception is used to abort the visitor pattern when an error occurs.
+    class CodeGenAbort
+    {
+    };
+
     // Local exception that is only used in this file to exit the visitor
     // pattern and caught later (not propagated outside)
     class CodeGenError {
@@ -24,52 +29,128 @@ namespace {
         diag::Diagnostic d;
 
     public:
-        CodeGenError(const std::string &msg) : d{diag::Diagnostic(msg, diag::Level::Error, diag::Stage::CodeGen)} {}
+        CodeGenError(const std::string &msg)
+            : d{diag::Diagnostic(msg, diag::Level::Error, diag::Stage::CodeGen)}
+        { }
+
+        CodeGenError(const std::string &msg, const Location &loc)
+            : d{diag::Diagnostic(msg, diag::Level::Error, diag::Stage::CodeGen, {
+                diag::Label("", {loc})
+            })}
+        { }
     };
 
 }  // namespace
 
+
+struct import_func{
+    std::string name;
+    std::vector<uint8_t> param_types, result_types;
+};
+
+
 class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
    public:
     Allocator &m_al;
-    ASR::Variable_t *return_var;
+    diag::Diagnostics &diag;
 
-    Vec<uint8_t> m_preamble;
+    ASR::Variable_t *return_var;
+    bool is_return_visited;
+
     Vec<uint8_t> m_type_section;
+    Vec<uint8_t> m_import_section;
     Vec<uint8_t> m_func_section;
     Vec<uint8_t> m_export_section;
     Vec<uint8_t> m_code_section;
+    Vec<uint8_t> m_data_section;
 
     uint32_t cur_func_idx;
+    uint32_t no_of_functions;
+    uint32_t no_of_imports;
+    uint32_t no_of_data_segments;  
+    uint32_t last_str_len;
+    uint32_t avail_mem_loc;
+    
     std::map<std::string, int32_t> m_var_name_idx_map;
     std::map<std::string, int32_t> m_func_name_idx_map;
 
    public:
-    ASRToWASMVisitor(Allocator &al) : m_al{al} {
+    ASRToWASMVisitor(Allocator &al, diag::Diagnostics &diagnostics): m_al(al), diag(diagnostics) {
         cur_func_idx = 0;
-        m_preamble.reserve(m_al, 1024 * 128);
+        avail_mem_loc = 0;
+        no_of_functions = 0;
+        no_of_imports = 0;
+        no_of_data_segments = 0;
         m_type_section.reserve(m_al, 1024 * 128);
+        m_import_section.reserve(m_al, 1024 * 128);
         m_func_section.reserve(m_al, 1024 * 128);
         m_export_section.reserve(m_al, 1024 * 128);
         m_code_section.reserve(m_al, 1024 * 128);
+        m_data_section.reserve(m_al, 1024 * 128);
     }
 
     void visit_TranslationUnit(const ASR::TranslationUnit_t &x) {
+        uint32_t len_idx_type_section = wasm::emit_len_placeholder(m_type_section, m_al);
+        uint32_t len_idx_import_section = wasm::emit_len_placeholder(m_import_section, m_al);
+        uint32_t len_idx_func_section = wasm::emit_len_placeholder(m_func_section, m_al);
+        uint32_t len_idx_export_section = wasm::emit_len_placeholder(m_export_section, m_al);
+        uint32_t len_idx_code_section = wasm::emit_len_placeholder(m_code_section, m_al);
+        uint32_t len_idx_data_section = wasm::emit_len_placeholder(m_data_section, m_al);
+
         // the main program:
         for (auto &item : x.m_global_scope->get_scope()) {
             if (ASR::is_a<ASR::Program_t>(*item.second)) {
                 visit_symbol(*item.second);
             }
         }
+
+        wasm::emit_u32_b32_idx(m_type_section, m_al, len_idx_type_section, cur_func_idx); // cur_func_idx indicates the total (imported + defined) no of functions
+        wasm::emit_u32_b32_idx(m_import_section, m_al, len_idx_import_section, no_of_imports);
+        wasm::emit_u32_b32_idx(m_func_section, m_al, len_idx_func_section, no_of_functions);
+        wasm::emit_u32_b32_idx(m_export_section, m_al, len_idx_export_section, no_of_functions);
+        wasm::emit_u32_b32_idx(m_code_section, m_al, len_idx_code_section, no_of_functions);
+        wasm::emit_u32_b32_idx(m_data_section, m_al, len_idx_data_section, no_of_data_segments);
     }
 
-    void visit_Program(const ASR::Program_t &x) {
-        wasm::emit_header(m_preamble, m_al);  // emit header and version
+    void emit_imports(){
+        std::vector<import_func> import_funcs = {
+            {"print_i32", { wasm::type::i32 }, {}},
+            {"print_i64", { wasm::type::i64 }, {}},
+            {"print_f32", { wasm::type::f32 }, {}},
+            {"print_f64", { wasm::type::f64 }, {}},
+            {"print_str", { wasm::type::i32, wasm::type::i32 }, {}},
+            {"flush_buf", {}, {}}
+        };
 
-        uint32_t len_idx_type_section = wasm::emit_len_placeholder(m_type_section, m_al);
-        uint32_t len_idx_func_section = wasm::emit_len_placeholder(m_func_section, m_al);
-        uint32_t len_idx_export_section = wasm::emit_len_placeholder(m_export_section, m_al);
-        uint32_t len_idx_code_section = wasm::emit_len_placeholder(m_code_section, m_al);
+        for(auto import_func:import_funcs){
+            wasm::emit_import_fn(m_import_section, m_al, "js", import_func.name, cur_func_idx);
+            // add their types to type section
+            wasm::emit_b8(m_type_section, m_al, 0x60);  // type section
+
+            wasm::emit_u32(m_type_section, m_al, import_func.param_types.size());
+            for(auto &param_type:import_func.param_types){
+                wasm::emit_b8(m_type_section, m_al, param_type);
+            }
+
+            wasm::emit_u32(m_type_section, m_al, import_func.result_types.size());
+            for(auto &result_type:import_func.result_types){
+                wasm::emit_b8(m_type_section, m_al, result_type);
+            }
+
+            m_func_name_idx_map[import_func.name] = cur_func_idx++;
+            no_of_imports++;
+        }
+
+        wasm::emit_import_mem(m_import_section, m_al, "js", "memory", 10U /* min page limit */, 10U /* max page limit */);
+        no_of_imports++;
+    }
+    
+    
+    void visit_Program(const ASR::Program_t &x) {
+        
+        emit_imports();
+
+        no_of_functions = 0;
 
         for (auto &item : x.m_symtab->get_scope()) {
             if (ASR::is_a<ASR::Subroutine_t>(*item.second)) {
@@ -78,89 +159,156 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             if (ASR::is_a<ASR::Function_t>(*item.second)) {
                 ASR::Function_t *s = ASR::down_cast<ASR::Function_t>(item.second);
                 visit_Function(*s);
+                no_of_functions++;
             }
         }
 
-        wasm::emit_u32_b32_idx(m_type_section, len_idx_type_section, cur_func_idx);
-        wasm::emit_u32_b32_idx(m_func_section, len_idx_func_section, cur_func_idx);
-        wasm::emit_u32_b32_idx(m_export_section, len_idx_export_section, cur_func_idx);
-        wasm::emit_u32_b32_idx(m_code_section, len_idx_code_section, cur_func_idx);
-    }
+        // Generate main program code
+        sprintf(x.m_name, "_lcompilers_main");
+        m_var_name_idx_map.clear(); // clear all previous variable and their indices
+        wasm::emit_b8(m_type_section, m_al, 0x60);  // new type declaration starts here
+        m_func_name_idx_map[x.m_name] = cur_func_idx;
 
-    void visit_Function(const ASR::Function_t &x) {
-        wasm::emit_b8(m_type_section, m_al, 0x60);  // type section
-
-        uint32_t len_idx_type_section_param_types_list = wasm::emit_len_placeholder(m_type_section, m_al);
-        int curIdx = 0;
-        for (size_t i = 0; i < x.n_args; i++) {
-            ASR::Variable_t *arg = LFortran::ASRUtils::EXPR2VAR(x.m_args[i]);
-            LFORTRAN_ASSERT(LFortran::ASRUtils::is_arg_dummy(arg->m_intent));
-            if (ASR::is_a<ASR::Integer_t>(*arg->m_type)) {
-                // checking for array is currently omitted
-                bool is_int32 = ASR::down_cast<ASR::Integer_t>(arg->m_type)->m_kind == 4;
-                if (is_int32) {
-                    wasm::emit_b8(m_type_section, m_al, 0x7F);  // i32
-                } else {
-                    wasm::emit_b8(m_type_section, m_al, 0x7E);  // i64
-                }
-                m_var_name_idx_map[arg->m_name] = curIdx++;
-            } else {
-                throw CodeGenError("Parameters other than integer not yet supported");
-            }
-        }
-        wasm::fixup_len(m_type_section, len_idx_type_section_param_types_list);
-
-        uint32_t len_idx_type_section_return_types_list = wasm::emit_len_placeholder(m_type_section, m_al);
-        return_var = LFortran::ASRUtils::EXPR2VAR(x.m_return_var);
-        if (ASRUtils::is_integer(*return_var->m_type)) {
-            bool is_int32 = ASR::down_cast<ASR::Integer_t>(return_var->m_type)->m_kind == 4;
-            if (is_int32) {
-                wasm::emit_b8(m_type_section, m_al, 0x7F);  // i32
-            } else {
-                wasm::emit_b8(m_type_section, m_al, 0x7E);  // i64
-            }
-        } else {
-            throw CodeGenError("Return type not supported");
-        }
-        wasm::fixup_len(m_type_section, len_idx_type_section_return_types_list);
-
+        wasm::emit_u32(m_type_section, m_al, 0U); // emit parameter types length = 0
+        wasm::emit_u32(m_type_section, m_al, 0U); // emit result types length = 0
+        
+        /********************* Function Body Starts Here *********************/
         uint32_t len_idx_code_section_func_size = wasm::emit_len_placeholder(m_code_section, m_al);
+        
+        /********************* Local Vars Types List *********************/
         uint32_t len_idx_code_section_local_vars_list = wasm::emit_len_placeholder(m_code_section, m_al);
-        int local_vars_cnt = 0;
+        int local_vars_cnt = 0, cur_idx = 0;
         for (auto &item : x.m_symtab->get_scope()) {
             if (ASR::is_a<ASR::Variable_t>(*item.second)) {
                 ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(item.second);
-                if (v->m_intent == LFortran::ASRUtils::intent_local || v->m_intent == LFortran::ASRUtils::intent_return_var) {
-                    if (ASR::is_a<ASR::Integer_t>(*v->m_type)) {
-                        wasm::emit_u32(m_code_section, m_al, 1);    // count of local vars of this type
-                        bool is_int32 = ASR::down_cast<ASR::Integer_t>(v->m_type)->m_kind == 4;
-                        if (is_int32) {
-                            wasm::emit_b8(m_code_section, m_al, 0x7F);  // i32
-                        } else {
-                            wasm::emit_b8(m_code_section, m_al, 0x7E);  // i64
-                        }
-                        m_var_name_idx_map[v->m_name] = curIdx++;
-                        local_vars_cnt++;
-                    } else {
-                        throw CodeGenError("Variables other than integer not yet supported");
-                    }
-                }
+                wasm::emit_u32(m_code_section, m_al, 1U);    // count of local vars of this type
+                emit_var_type(m_code_section, v); // emit the type of this var
+                m_var_name_idx_map[v->m_name] = cur_idx++;
+                local_vars_cnt++;
             }
         }
         // fixup length of local vars list
-        wasm::emit_u32_b32_idx(m_code_section, len_idx_code_section_local_vars_list, local_vars_cnt);
+        wasm::emit_u32_b32_idx(m_code_section, m_al, len_idx_code_section_local_vars_list, local_vars_cnt);
 
         for (size_t i = 0; i < x.n_body; i++) {
             this->visit_stmt(*x.m_body[i]);
         }
 
         wasm::emit_expr_end(m_code_section, m_al);
-        wasm::fixup_len(m_code_section, len_idx_code_section_func_size);
+        wasm::fixup_len(m_code_section, m_al, len_idx_code_section_func_size);
 
         wasm::emit_u32(m_func_section, m_al, cur_func_idx);
 
         wasm::emit_export_fn(m_export_section, m_al, x.m_name, cur_func_idx);
-        m_func_name_idx_map[x.m_name] = cur_func_idx++;
+
+        cur_func_idx++;
+        no_of_functions++;
+    }
+
+    void emit_var_type(Vec<uint8_t> &code, ASR::Variable_t *v){
+        if (ASRUtils::is_integer(*v->m_type)) {
+            // checking for array is currently omitted
+            ASR::Integer_t* v_int = ASR::down_cast<ASR::Integer_t>(v->m_type);
+            if (v_int->m_kind == 4) {
+                wasm::emit_b8(code, m_al, wasm::type::i32);
+            }
+            else if (v_int->m_kind == 8) {
+                wasm::emit_b8(code, m_al, wasm::type::i64);
+            }
+            else{
+                throw CodeGenError("Integers of kind 4 and 8 only supported");
+            }
+        } else if (ASRUtils::is_real(*v->m_type)) {
+            // checking for array is currently omitted
+            ASR::Real_t* v_float = ASR::down_cast<ASR::Real_t>(v->m_type);
+            if (v_float->m_kind == 4) {
+                wasm::emit_b8(code, m_al, wasm::type::f32);
+            }
+            else if(v_float->m_kind == 8){
+                wasm::emit_b8(code, m_al, wasm::type::f64);
+            } 
+            else {
+                throw CodeGenError("Floating Points of kind 4 and 8 only supported");
+            }
+        } else if (ASRUtils::is_logical(*v->m_type)) {
+            // checking for array is currently omitted
+            ASR::Logical_t* v_logical = ASR::down_cast<ASR::Logical_t>(v->m_type);
+            if (v_logical->m_kind == 4) {
+                wasm::emit_b8(code, m_al, wasm::type::i32);
+            }
+            else if(v_logical->m_kind == 8){
+                wasm::emit_b8(code, m_al, wasm::type::i64);
+            } 
+            else {
+                throw CodeGenError("Logicals of kind 4 and 8 only supported");
+            }
+        } else {
+            throw CodeGenError("Param, Result, Var Types other than integer, floating point and logical not yet supported");
+        }
+    }
+
+    void visit_Function(const ASR::Function_t &x) {
+        m_var_name_idx_map.clear(); // clear all previous variable and their indices
+
+        wasm::emit_b8(m_type_section, m_al, 0x60);  // new type declaration starts here
+        
+        m_func_name_idx_map[x.m_name] = cur_func_idx; // add func to map early to support recursive func calls
+
+        /********************* Parameter Types List *********************/
+        uint32_t len_idx_type_section_param_types_list = wasm::emit_len_placeholder(m_type_section, m_al);
+        int cur_idx = 0;
+        for (size_t i = 0; i < x.n_args; i++) {
+            ASR::Variable_t *arg = LFortran::ASRUtils::EXPR2VAR(x.m_args[i]);
+            LFORTRAN_ASSERT(LFortran::ASRUtils::is_arg_dummy(arg->m_intent));
+            emit_var_type(m_type_section, arg);
+            m_var_name_idx_map[arg->m_name] = cur_idx++;
+        }
+        wasm::fixup_len(m_type_section, m_al, len_idx_type_section_param_types_list);
+
+        /********************* Result Types List *********************/
+        uint32_t len_idx_type_section_return_types_list = wasm::emit_len_placeholder(m_type_section, m_al);
+        return_var = LFortran::ASRUtils::EXPR2VAR(x.m_return_var);
+        emit_var_type(m_type_section, return_var);
+        wasm::fixup_len(m_type_section, m_al, len_idx_type_section_return_types_list);
+        is_return_visited = false; // for every function initialize is_return_visited to false
+
+        /********************* Function Body Starts Here *********************/
+        uint32_t len_idx_code_section_func_size = wasm::emit_len_placeholder(m_code_section, m_al);
+        
+        /********************* Local Vars Types List *********************/
+        uint32_t len_idx_code_section_local_vars_list = wasm::emit_len_placeholder(m_code_section, m_al);
+        int local_vars_cnt = 0;
+        for (auto &item : x.m_symtab->get_scope()) {
+            if (ASR::is_a<ASR::Variable_t>(*item.second)) {
+                ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(item.second);
+                if (v->m_intent == LFortran::ASRUtils::intent_local || v->m_intent == LFortran::ASRUtils::intent_return_var) {
+                    wasm::emit_u32(m_code_section, m_al, 1U);    // count of local vars of this type
+                    emit_var_type(m_code_section, v); // emit the type of this var
+                    m_var_name_idx_map[v->m_name] = cur_idx++;
+                    local_vars_cnt++;
+                }
+            }
+        }
+        // fixup length of local vars list
+        wasm::emit_u32_b32_idx(m_code_section, m_al, len_idx_code_section_local_vars_list, local_vars_cnt);
+
+        for (size_t i = 0; i < x.n_body; i++) {
+            this->visit_stmt(*x.m_body[i]);
+        }
+
+        if(!is_return_visited){
+            ASR::Return_t temp;
+            visit_Return(temp);
+        }
+
+        wasm::emit_expr_end(m_code_section, m_al);
+        wasm::fixup_len(m_code_section, m_al, len_idx_code_section_func_size);
+
+        wasm::emit_u32(m_func_section, m_al, cur_func_idx);
+
+        wasm::emit_export_fn(m_export_section, m_al, x.m_name, cur_func_idx);
+
+        cur_func_idx++;
     }
 
     void visit_Assignment(const ASR::Assignment_t &x) {
@@ -168,7 +316,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         // this->visit_expr(*x.m_target);
         if (ASR::is_a<ASR::Var_t>(*x.m_target)) {
             ASR::Variable_t *asr_target = LFortran::ASRUtils::EXPR2VAR(x.m_target);
-
+            LFORTRAN_ASSERT(m_var_name_idx_map.find(asr_target->m_name) != m_var_name_idx_map.end());
             wasm::emit_set_local(m_code_section, m_al, m_var_name_idx_map[asr_target->m_name]);
         } else if (ASR::is_a<ASR::ArrayRef_t>(*x.m_target)) {
             throw CodeGenError("Assignment: Arrays not yet supported");
@@ -177,60 +325,154 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         }
     }
 
-    void visit_BinOp(const ASR::BinOp_t &x) {
+    void visit_IntegerBinOp(const ASR::IntegerBinOp_t &x) {
+        if (x.m_value) { 
+            visit_expr(*x.m_value); 
+            return; 
+        }
         this->visit_expr(*x.m_left);
-
         this->visit_expr(*x.m_right);
-
-        if (ASRUtils::is_integer(*x.m_type)) {
-            ASR::Integer_t *i = ASR::down_cast<ASR::Integer_t>(x.m_type);
-            if (i->m_kind == 4) {
-                switch (x.m_op) {
-                    case ASR::binopType::Add: {
-                        wasm::emit_i32_add(m_code_section, m_al);
-                        break;
-                    };
-                    case ASR::binopType::Sub: {
-                        wasm::emit_i32_sub(m_code_section, m_al);
-                        break;
-                    };
-                    case ASR::binopType::Mul: {
-                        wasm::emit_i32_mul(m_code_section, m_al);
-                        break;
-                    };
-                    case ASR::binopType::Div: {
-                        wasm::emit_i32_div(m_code_section, m_al);
-                        break;
-                    };
-                    default:
-                        throw CodeGenError("Binop: Pow Operation not yet implemented");
-                }
-            } else if (i->m_kind == 8) {
-                switch (x.m_op) {
-                    case ASR::binopType::Add: {
-                        wasm::emit_i64_add(m_code_section, m_al);
-                        break;
-                    };
-                    case ASR::binopType::Sub: {
-                        wasm::emit_i64_sub(m_code_section, m_al);
-                        break;
-                    };
-                    case ASR::binopType::Mul: {
-                        wasm::emit_i64_mul(m_code_section, m_al);
-                        break;
-                    };
-                    case ASR::binopType::Div: {
-                        wasm::emit_i64_div(m_code_section, m_al);
-                        break;
-                    };
-                    default:
-                        throw CodeGenError("Binop: Pow Operation not yet implemented");
-                }
-            } else {
-                throw CodeGenError("Binop: Integer kind not supported");
+        ASR::Integer_t *i = ASR::down_cast<ASR::Integer_t>(x.m_type);
+        if (i->m_kind == 4) {
+            switch (x.m_op) {
+                case ASR::binopType::Add: {
+                    wasm::emit_i32_add(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Sub: {
+                    wasm::emit_i32_sub(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Mul: {
+                    wasm::emit_i32_mul(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Div: {
+                    wasm::emit_i32_div_s(m_code_section, m_al);
+                    break;
+                };
+                default:
+                    throw CodeGenError("IntegerBinop: Pow Operation not yet implemented");
+            }
+        } else if (i->m_kind == 8) {
+            switch (x.m_op) {
+                case ASR::binopType::Add: {
+                    wasm::emit_i64_add(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Sub: {
+                    wasm::emit_i64_sub(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Mul: {
+                    wasm::emit_i64_mul(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Div: {
+                    wasm::emit_i64_div_s(m_code_section, m_al);
+                    break;
+                };
+                default:
+                    throw CodeGenError("IntegerBinop: Pow Operation not yet implemented");
             }
         } else {
-            throw CodeGenError("Binop: Only Integer type implemented");
+            throw CodeGenError("IntegerBinop: Integer kind not supported");
+        }
+    }
+
+    void visit_RealBinOp(const ASR::RealBinOp_t &x) {
+        if (x.m_value) { 
+            visit_expr(*x.m_value); 
+            return; 
+        }
+        this->visit_expr(*x.m_left);
+        this->visit_expr(*x.m_right);
+        ASR::Real_t *f = ASR::down_cast<ASR::Real_t>(x.m_type);
+        if (f->m_kind == 4) {
+            switch (x.m_op) {
+                case ASR::binopType::Add: {
+                    wasm::emit_f32_add(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Sub: {
+                    wasm::emit_f32_sub(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Mul: {
+                    wasm::emit_f32_mul(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Div: {
+                    wasm::emit_f32_div(m_code_section, m_al);
+                    break;
+                };
+                default:
+                    throw CodeGenError("RealBinop: Pow Operation not yet implemented");
+            }
+        } else if (f->m_kind == 8) {
+            switch (x.m_op) {
+                case ASR::binopType::Add: {
+                    wasm::emit_f64_add(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Sub: {
+                    wasm::emit_f64_sub(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Mul: {
+                    wasm::emit_f64_mul(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Div: {
+                    wasm::emit_f64_div(m_code_section, m_al);
+                    break;
+                };
+                default:
+                    throw CodeGenError("RealBinop: Pow Operation not yet implemented");
+            }
+        } else {
+            throw CodeGenError("RealBinop: Real kind not supported");
+        }
+    }
+
+    void visit_IntegerUnaryMinus(const ASR::IntegerUnaryMinus_t &x) {
+         if (x.m_value) { 
+            visit_expr(*x.m_value); 
+            return; 
+        }
+        ASR::Integer_t *i = ASR::down_cast<ASR::Integer_t>(x.m_type);
+        // there seems no direct unary-minus inst in wasm, so subtracting from 0
+        if(i->m_kind == 4){
+            wasm::emit_i32_const(m_code_section, m_al, 0);
+            this->visit_expr(*x.m_arg);
+            wasm::emit_i32_sub(m_code_section, m_al);
+        }
+        else if(i->m_kind == 8){
+            wasm::emit_i64_const(m_code_section, m_al, 0LL);
+            this->visit_expr(*x.m_arg);
+            wasm::emit_i64_sub(m_code_section, m_al);
+        }
+        else{
+            throw CodeGenError("IntegerUnaryMinus: Only kind 4 and 8 supported");
+        }
+    }
+
+    void visit_RealUnaryMinus(const ASR::RealUnaryMinus_t &x) {
+         if (x.m_value) { 
+            visit_expr(*x.m_value); 
+            return; 
+        }
+        ASR::Real_t *f = ASR::down_cast<ASR::Real_t>(x.m_type);
+        if(f->m_kind == 4){
+            this->visit_expr(*x.m_arg);
+            wasm::emit_f32_neg(m_code_section, m_al);
+        }
+        else if(f->m_kind == 8){
+            this->visit_expr(*x.m_arg);
+            wasm::emit_f64_neg(m_code_section, m_al);
+        }
+        else{
+            throw CodeGenError("RealUnaryMinus: Only kind 4 and 8 supported");
         }
     }
 
@@ -239,18 +481,23 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         auto v = ASR::down_cast<ASR::Variable_t>(s);
         switch (v->m_type->type) {
             case ASR::ttypeType::Integer:
-                // currently omitting check for 64 bit integers
+            case ASR::ttypeType::Logical:
+            case ASR::ttypeType::Real: {
+                LFORTRAN_ASSERT(m_var_name_idx_map.find(v->m_name) != m_var_name_idx_map.end());
                 wasm::emit_get_local(m_code_section, m_al, m_var_name_idx_map[v->m_name]);
                 break;
-
+            }
+            
             default:
-                throw CodeGenError("Variable type not supported");
+                throw CodeGenError("Only Integer and Float Variable types currently supported");
         }
     }
 
     void visit_Return(const ASR::Return_t & /* x */) {
+        LFORTRAN_ASSERT(m_var_name_idx_map.find(return_var->m_name) != m_var_name_idx_map.end());
         wasm::emit_get_local(m_code_section, m_al, m_var_name_idx_map[return_var->m_name]);
-        wasm::emit_b8(m_code_section, m_al, 0x0F);
+        wasm::emit_b8(m_code_section, m_al, 0x0F); // return instruction
+        is_return_visited = true;
     }
 
     void visit_IntegerConstant(const ASR::IntegerConstant_t &x) {
@@ -261,10 +508,58 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                 wasm::emit_i32_const(m_code_section, m_al, val);
                 break;
             }
+            case 8: {
+                wasm::emit_i64_const(m_code_section, m_al, val);
+                break;
+            }
             default: {
-                throw CodeGenError("Constant Integer: Only kind 4 currently supported");
+                throw CodeGenError("Constant Integer: Only kind 4 and 8 supported");
             }
         }
+    }
+
+    void visit_RealConstant(const ASR::RealConstant_t &x) {
+        double val = x.m_r;
+        int a_kind = ((ASR::Real_t *)(&(x.m_type->base)))->m_kind;
+        switch (a_kind) {
+            case 4: {
+                wasm::emit_f32_const(m_code_section, m_al, val);
+                break;
+            }
+            case 8: {
+                wasm::emit_f64_const(m_code_section, m_al, val);
+                break;
+            }
+            default: {
+                throw CodeGenError("Constant Real: Only kind 4 and 8 supported");
+            }
+        }
+    }
+
+    void visit_LogicalConstant(const ASR::LogicalConstant_t &x) {
+        bool val = x.m_value;
+        int a_kind = ((ASR::Logical_t *)(&(x.m_type->base)))->m_kind;
+        switch (a_kind) {
+            case 4: {
+                wasm::emit_i32_const(m_code_section, m_al, val);
+                break;
+            }
+            case 8: {
+                wasm::emit_i64_const(m_code_section, m_al, val);
+                break;
+            }
+            default: {
+                throw CodeGenError("Constant Logical: Only kind 4 and 8 supported");
+            }
+        }
+    }
+
+    void visit_StringConstant(const ASR::StringConstant_t &x){
+        // Todo: Add a check here if there is memory available to store the given string
+        wasm::emit_str_const(m_data_section, m_al, avail_mem_loc, x.m_s);
+        last_str_len = strlen(x.m_s);
+        avail_mem_loc += last_str_len;
+        no_of_data_segments++;
     }
 
     void visit_FunctionCall(const ASR::FunctionCall_t &x) {
@@ -274,80 +569,201 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             visit_expr(*x.m_args[i].m_value);
         }
 
+        LFORTRAN_ASSERT(m_func_name_idx_map.find(fn->m_name) != m_func_name_idx_map.end())
         wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[fn->m_name]);
+    }
+
+    template <typename T>
+    void handle_print(const T &x){
+        for (size_t i=0; i<x.n_values; i++) {
+            this->visit_expr(*x.m_values[i]);
+            ASR::expr_t *v = x.m_values[i];
+            ASR::ttype_t *t = ASRUtils::expr_type(v);
+            int a_kind = ASRUtils::extract_kind_from_ttype_t(t);
+
+            if (ASRUtils::is_integer(*t)) {
+                switch( a_kind ) {
+                    case 4 : {
+                        // the value is already on stack. call JavaScript print_i32
+                        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["print_i32"]);
+                        break;
+                    }
+                    case 8 : {
+                        // the value is already on stack. call JavaScript print_i64
+                        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["print_i64"]);
+                        break;
+                    }
+                    default: {
+                        throw CodeGenError(R"""(Printing support is currently available only
+                                            for 32, and 64 bit integer kinds.)""");
+                    }
+                }
+            } else if (ASRUtils::is_real(*t)) {
+                switch( a_kind ) {
+                    case 4 : {
+                        // the value is already on stack. call JavaScript print_f32
+                        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["print_f32"]);
+                        break;
+                    }
+                    case 8 : {
+                        // the value is already on stack. call JavaScript print_f64
+                        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["print_f64"]);
+                        break;
+                    }
+                    default: {
+                        throw CodeGenError(R"""(Printing support is available only
+                                            for 32, and 64 bit real kinds.)""");
+                    }
+                }
+            } else if (t->type == ASR::ttypeType::Character) {
+                // push string location and its size on function stack
+                wasm::emit_i32_const(m_code_section, m_al, avail_mem_loc - last_str_len);
+                wasm::emit_i32_const(m_code_section, m_al, last_str_len);
+
+                // call JavaScript printStr
+                wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["print_str"]);
+                
+            } 
+        }
+
+        // call JavaScript Flush
+        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["flush_buf"]);
+    }
+
+    void visit_Print(const ASR::Print_t &x){
+        if (x.m_fmt != nullptr) {
+            diag.codegen_warning_label("format string in `print` is not implemented yet and it is currently treated as '*'",
+                {x.m_fmt->base.loc}, "treated as '*'");
+        }
+        handle_print(x);
+    }
+
+    void visit_FileWrite(const ASR::FileWrite_t &x) {
+        if (x.m_fmt != nullptr) {
+            diag.codegen_warning_label("format string in `print` is not implemented yet and it is currently treated as '*'",
+                {x.m_fmt->base.loc}, "treated as '*'");
+        }
+        if (x.m_unit != nullptr) {
+            diag.codegen_error_label("unit in write() is not implemented yet",
+                {x.m_unit->base.loc}, "not implemented");
+            throw CodeGenAbort();
+        }
+        handle_print(x);
+    }
+
+    void visit_FileRead(const ASR::FileRead_t &x) {
+        if (x.m_fmt != nullptr) {
+            diag.codegen_warning_label("format string in read() is not implemented yet and it is currently treated as '*'",
+                {x.m_fmt->base.loc}, "treated as '*'");
+        }
+        if (x.m_unit != nullptr) {
+            diag.codegen_error_label("unit in read() is not implemented yet",
+                {x.m_unit->base.loc}, "not implemented");
+            throw CodeGenAbort();
+        }
+        diag.codegen_error_label("The intrinsic function read() is not implemented yet in the LLVM backend",
+            {x.base.base.loc}, "not implemented");
+        throw CodeGenAbort();
+    }
+
+    void print_msg(std::string msg) {
+        ASR::StringConstant_t n;
+        n.m_s = new char[msg.length() + 1];
+        strcpy(n.m_s, msg.c_str());
+        visit_StringConstant(n);
+        wasm::emit_i32_const(m_code_section, m_al, avail_mem_loc - last_str_len);
+        wasm::emit_i32_const(m_code_section, m_al, last_str_len);
+        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["print_str"]);
+        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["flush_buf"]);
+    }
+
+    void exit() {
+        // exit_code would be on stack, so add it to JavaScript Output buffer by printing it.
+        // this exit code would be read by JavaScript glue code
+        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["print_i32"]);
+        wasm::emit_unreachable(m_code_section, m_al); // raise trap/exception
+    }
+
+    void visit_Stop(const ASR::Stop_t &x) {
+        print_msg("STOP");
+        if (x.m_code && ASRUtils::expr_type(x.m_code)->type == ASR::ttypeType::Integer) {
+            this->visit_expr(*x.m_code);
+        } else {
+            wasm::emit_i32_const(m_code_section, m_al, 0); // zero exit code
+        }
+        exit();
+    }
+
+    void visit_ErrorStop(const ASR::ErrorStop_t & /* x */) {
+        print_msg("ERROR STOP");
+        wasm::emit_i32_const(m_code_section, m_al, 1); // non-zero exit code
+        exit();
+    }
+
+    void visit_If(const ASR::If_t &x) {
+        this->visit_expr(*x.m_test);
+        wasm::emit_b8(m_code_section, m_al, 0x04);
+        wasm::emit_b8(m_code_section, m_al, 0x40); // empty block type
+        for (size_t i=0; i<x.n_body; i++) {
+            this->visit_stmt(*x.m_body[i]);
+        }
+        if(x.n_orelse){
+            wasm::emit_b8(m_code_section, m_al, 0x05); // starting of else
+            for (size_t i=0; i<x.n_orelse; i++) {
+                this->visit_stmt(*x.m_orelse[i]);
+            }
+        }
+        wasm::emit_expr_end(m_code_section, m_al);
     }
 };
 
-Result<Vec<uint8_t>> asr_to_wasm_bytes_stream(ASR::TranslationUnit_t &asr, Allocator &al) {
-    ASRToWASMVisitor v(al);
+Result<Vec<uint8_t>> asr_to_wasm_bytes_stream(ASR::TranslationUnit_t &asr, Allocator &al, diag::Diagnostics &diagnostics) {
+    ASRToWASMVisitor v(al, diagnostics);
     Vec<uint8_t> wasm_bytes;
     
     pass_wrap_global_stmts_into_function(al, asr, "f");
     pass_replace_do_loops(al, asr);
     
     try {
-        wasm::emit_u32(v.m_type_section, v.m_al, 1);
-        wasm::emit_u32(v.m_func_section, v.m_al, 3);
-        wasm::emit_u32(v.m_export_section, v.m_al, 7);
-        wasm::emit_u32(v.m_code_section, v.m_al, 10);
-
-        uint32_t len_idx_type_section = wasm::emit_len_placeholder(v.m_type_section, v.m_al);
-        uint32_t len_idx_func_section = wasm::emit_len_placeholder(v.m_func_section, v.m_al);
-        uint32_t len_idx_export_section = wasm::emit_len_placeholder(v.m_export_section, v.m_al);
-        uint32_t len_idx_code_section = wasm::emit_len_placeholder(v.m_code_section, v.m_al);
-
         v.visit_asr((ASR::asr_t &)asr);
-
-        wasm::fixup_len(v.m_type_section, len_idx_type_section);
-        wasm::fixup_len(v.m_func_section, len_idx_func_section);
-        wasm::fixup_len(v.m_export_section, len_idx_export_section);
-        wasm::fixup_len(v.m_code_section, len_idx_code_section);
-
     } catch (const CodeGenError &e) {
-        Error error;
-        return error;
+        diagnostics.diagnostics.push_back(e.d);
+        return Error();
     }
 
     {
-        wasm_bytes.reserve(al, v.m_preamble.size() + v.m_type_section.size() + v.m_func_section.size() + v.m_export_section.size() + v.m_code_section.size());
-        for (auto &byte : v.m_preamble) {
-            wasm_bytes.push_back(al, byte);
-        }
-        for (auto &byte : v.m_type_section) {
-            wasm_bytes.push_back(al, byte);
-        }
-        for (auto &byte : v.m_func_section) {
-            wasm_bytes.push_back(al, byte);
-        }
-        for (auto &byte : v.m_export_section) {
-            wasm_bytes.push_back(al, byte);
-        }
-        for (auto &byte : v.m_code_section) {
-            wasm_bytes.push_back(al, byte);
-        }
+        wasm_bytes.reserve(al, 8U /* preamble size */ + 8U /* (section id + section size) */ * 6U /* number of sections */ 
+            + v.m_type_section.size() + v.m_import_section.size() + v.m_func_section.size() 
+            + v.m_export_section.size() + v.m_code_section.size() + v.m_data_section.size());
+        
+        wasm::emit_header(wasm_bytes, al);  // emit header and version
+        wasm::encode_section(wasm_bytes, v.m_type_section, al, 1U);
+        wasm::encode_section(wasm_bytes, v.m_import_section, al, 2U);
+        wasm::encode_section(wasm_bytes, v.m_func_section, al, 3U);
+        wasm::encode_section(wasm_bytes, v.m_export_section, al, 7U);
+        wasm::encode_section(wasm_bytes, v.m_code_section, al, 10U);
+        wasm::encode_section(wasm_bytes, v.m_data_section, al, 11U);
     }
 
     return wasm_bytes;
 }
 
-Result<int> asr_to_wasm(ASR::TranslationUnit_t &asr, Allocator &al, const std::string &filename, bool time_report) {
+Result<int> asr_to_wasm(ASR::TranslationUnit_t &asr, Allocator &al, const std::string &filename,
+    bool time_report, diag::Diagnostics &diagnostics) {
     int time_visit_asr = 0;
     int time_save = 0;
 
     auto t1 = std::chrono::high_resolution_clock::now();
-    Result<Vec<uint8_t>> wasm = asr_to_wasm_bytes_stream(asr, al);
+    Result<Vec<uint8_t>> wasm = asr_to_wasm_bytes_stream(asr, al, diagnostics);
     auto t2 = std::chrono::high_resolution_clock::now();
     time_visit_asr = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
     if (!wasm.ok) {
-        Error error;
-        return error;
+        return wasm.error;
     }
 
     {
         auto t1 = std::chrono::high_resolution_clock::now();
-        FILE *fp = fopen(filename.c_str(), "wb");
-        fwrite(wasm.result.data(), sizeof(uint8_t), wasm.result.size(), fp);
-        fclose(fp);
+        wasm::save_bin(wasm.result, filename);
         auto t2 = std::chrono::high_resolution_clock::now();
         time_save = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
     }

--- a/src/libasr/codegen/asr_to_wasm.h
+++ b/src/libasr/codegen/asr_to_wasm.h
@@ -6,11 +6,11 @@
 namespace LFortran {
 
     // Generates a wasm binary stream from ASR
-    Result<Vec<uint8_t>> asr_to_wasm_bytes_stream(ASR::TranslationUnit_t &asr, Allocator &al);
+    Result<Vec<uint8_t>> asr_to_wasm_bytes_stream(ASR::TranslationUnit_t &asr, Allocator &al, diag::Diagnostics &diagnostics);
 
     // Generates a wasm binary to `filename`
     Result<int> asr_to_wasm(ASR::TranslationUnit_t &asr, Allocator &al,
-            const std::string &filename, bool time_report);
+            const std::string &filename, bool time_report, diag::Diagnostics &diagnostics);
 
 } // namespace LFortran
 

--- a/src/libasr/codegen/asr_to_x86.cpp
+++ b/src/libasr/codegen/asr_to_x86.cpp
@@ -302,61 +302,44 @@ public:
         }
     }
 
-    void visit_BinOp(const ASR::BinOp_t &x) {
+    void visit_IntegerBinOp(const ASR::IntegerBinOp_t &x) {
         this->visit_expr(*x.m_right);
         m_a.asm_push_r32(X86Reg::eax);
         this->visit_expr(*x.m_left);
         m_a.asm_pop_r32(X86Reg::ecx);
         // The left operand is in eax, the right operand is in ecx
         // Leave the result in eax.
-        if (x.m_type->type == ASR::ttypeType::Integer) {
-            switch (x.m_op) {
-                case ASR::binopType::Add: {
-                    m_a.asm_add_r32_r32(X86Reg::eax, X86Reg::ecx);
-                    break;
-                };
-                case ASR::binopType::Sub: {
-                    m_a.asm_sub_r32_r32(X86Reg::eax, X86Reg::ecx);
-                    break;
-                };
-                case ASR::binopType::Mul: {
-                    m_a.asm_mov_r32_imm32(X86Reg::edx, 0);
-                    m_a.asm_mul_r32(X86Reg::ecx);
-                    break;
-                };
-                case ASR::binopType::Div: {
-                    m_a.asm_mov_r32_imm32(X86Reg::edx, 0);
-                    m_a.asm_div_r32(X86Reg::ecx);
-                    break;
-                };
-                case ASR::binopType::Pow: {
-                    throw CodeGenError("Pow not implemented yet.");
-                    break;
-                };
+        switch (x.m_op) {
+            case ASR::binopType::Add: {
+                m_a.asm_add_r32_r32(X86Reg::eax, X86Reg::ecx);
+                break;
+            };
+            case ASR::binopType::Sub: {
+                m_a.asm_sub_r32_r32(X86Reg::eax, X86Reg::ecx);
+                break;
+            };
+            case ASR::binopType::Mul: {
+                m_a.asm_mov_r32_imm32(X86Reg::edx, 0);
+                m_a.asm_mul_r32(X86Reg::ecx);
+                break;
+            };
+            case ASR::binopType::Div: {
+                m_a.asm_mov_r32_imm32(X86Reg::edx, 0);
+                m_a.asm_div_r32(X86Reg::ecx);
+                break;
+            };
+            default: {
+                throw CodeGenError("Binary operator '" + ASRUtils::binop_to_str_python(x.m_op) + "' not supported yet");
             }
-        } else {
-            throw CodeGenError("Binop: Only Integer types implemented so far");
         }
     }
 
-    void visit_UnaryOp(const ASR::UnaryOp_t &x) {
-        this->visit_expr(*x.m_operand);
-        if (x.m_type->type == ASR::ttypeType::Integer) {
-            if (x.m_op == ASR::unaryopType::UAdd) {
-                // eax = eax
-                return;
-            } else if (x.m_op == ASR::unaryopType::USub) {
-                m_a.asm_neg_r32(X86Reg::eax);
-                return;
-            } else {
-                throw CodeGenError("Unary type not implemented yet");
-            }
-        } else {
-            throw CodeGenError("UnaryOp: type not supported yet");
-        }
+    void visit_IntegerUnaryMinus(const ASR::IntegerUnaryMinus_t &x) {
+        this->visit_expr(*x.m_arg);
+        m_a.asm_neg_r32(X86Reg::eax);
     }
 
-    void visit_Compare(const ASR::Compare_t &x) {
+    void visit_IntegerCompare(const ASR::IntegerCompare_t &x) {
         std::string id = std::to_string(get_hash((ASR::asr_t*)&x));
         this->visit_expr(*x.m_right);
         m_a.asm_push_r32(X86Reg::eax);
@@ -365,46 +348,40 @@ public:
         // The left operand is in eax, the right operand is in ecx
         // Leave the result in eax.
         m_a.asm_cmp_r32_r32(X86Reg::eax, X86Reg::ecx);
-        LFORTRAN_ASSERT(LFortran::ASRUtils::expr_type(x.m_left)->type == LFortran::ASRUtils::expr_type(x.m_right)->type);
-        ASR::ttypeType optype = LFortran::ASRUtils::expr_type(x.m_left)->type;
-        if (optype == ASR::ttypeType::Integer) {
-            switch (x.m_op) {
-                case (ASR::cmpopType::Eq) : {
-                    m_a.asm_je_label(".compare1" + id);
-                    break;
-                }
-                case (ASR::cmpopType::Gt) : {
-                    m_a.asm_jg_label(".compare1" + id);
-                    break;
-                }
-                case (ASR::cmpopType::GtE) : {
-                    m_a.asm_jge_label(".compare1" + id);
-                    break;
-                }
-                case (ASR::cmpopType::Lt) : {
-                    m_a.asm_jl_label(".compare1" + id);
-                    break;
-                }
-                case (ASR::cmpopType::LtE) : {
-                    m_a.asm_jle_label(".compare1" + id);
-                    break;
-                }
-                case (ASR::cmpopType::NotEq) : {
-                    m_a.asm_jne_label(".compare1" + id);
-                    break;
-                }
-                default : {
-                    throw CodeGenError("Comparison operator not implemented");
-                }
+        switch (x.m_op) {
+            case (ASR::cmpopType::Eq) : {
+                m_a.asm_je_label(".compare1" + id);
+                break;
             }
-            m_a.asm_mov_r32_imm32(X86Reg::eax, 0);
-            m_a.asm_jmp_label(".compareend" + id);
-            m_a.add_label(".compare1" + id);
-            m_a.asm_mov_r32_imm32(X86Reg::eax, 1);
-            m_a.add_label(".compareend" + id);
-        } else {
-            throw CodeGenError("Only Integer implemented in Compare");
+            case (ASR::cmpopType::Gt) : {
+                m_a.asm_jg_label(".compare1" + id);
+                break;
+            }
+            case (ASR::cmpopType::GtE) : {
+                m_a.asm_jge_label(".compare1" + id);
+                break;
+            }
+            case (ASR::cmpopType::Lt) : {
+                m_a.asm_jl_label(".compare1" + id);
+                break;
+            }
+            case (ASR::cmpopType::LtE) : {
+                m_a.asm_jle_label(".compare1" + id);
+                break;
+            }
+            case (ASR::cmpopType::NotEq) : {
+                m_a.asm_jne_label(".compare1" + id);
+                break;
+            }
+            default : {
+                throw CodeGenError("Comparison operator not implemented");
+            }
         }
+        m_a.asm_mov_r32_imm32(X86Reg::eax, 0);
+        m_a.asm_jmp_label(".compareend" + id);
+        m_a.add_label(".compare1" + id);
+        m_a.asm_mov_r32_imm32(X86Reg::eax, 1);
+        m_a.add_label(".compareend" + id);
     }
 
     void visit_Assignment(const ASR::Assignment_t &x) {

--- a/src/libasr/codegen/evaluator.cpp
+++ b/src/libasr/codegen/evaluator.cpp
@@ -157,6 +157,13 @@ LLVMEvaluator::LLVMEvaluator(const std::string &t)
     LLVMInitializeX86AsmPrinter();
     LLVMInitializeX86AsmParser();
 #endif
+#ifdef HAVE_TARGET_WASM
+    LLVMInitializeWebAssemblyTarget();
+    LLVMInitializeWebAssemblyTargetInfo();
+    LLVMInitializeWebAssemblyTargetMC();
+    LLVMInitializeWebAssemblyAsmPrinter();
+    LLVMInitializeWebAssemblyAsmParser();
+#endif
 
     context = std::make_unique<llvm::LLVMContext>();
 
@@ -423,6 +430,9 @@ void LLVMEvaluator::print_targets()
 #ifdef HAVE_TARGET_X86
     LLVMInitializeX86TargetInfo();
 #endif
+#ifdef HAVE_TARGET_WASM
+    LLVMInitializeWebAssemblyTargetInfo();
+#endif    
     llvm::raw_ostream &os = llvm::outs();
     llvm::TargetRegistry::printRegisteredTargetsForVersion(os);
 }

--- a/src/libasr/codegen/wasm_assembler.h
+++ b/src/libasr/codegen/wasm_assembler.h
@@ -6,37 +6,26 @@
 namespace LFortran {
 namespace wasm {
 
-std::vector<uint8_t> encode_signed_leb128(int32_t n) {
-    std::vector<uint8_t> out;
-    auto more = true;
-    do {
-        uint8_t byte = n & 0x7f;
-        n >>= 7;
-        more = !((((n == 0) && ((byte & 0x40) == 0)) ||
-                  ((n == -1) && ((byte & 0x40) != 0))));
-        if (more) {
-            byte |= 0x80;
-        }
-        out.emplace_back(byte);
-    } while (more);
-    return out;
-}
+enum type {
+    i32 = 0x7F,
+    i64 = 0x7E,
+    f32 = 0x7D,
+    f64 = 0x7C
+};
 
-std::vector<uint8_t> encode_unsigned_leb128(uint32_t n) {
-    std::vector<uint8_t> out;
+void emit_leb128_u32(Vec<uint8_t> &code, Allocator &al, uint32_t n) { // for u32
     do {
         uint8_t byte = n & 0x7f;
         n >>= 7;
         if (n != 0) {
             byte |= 0x80;
         }
-        out.emplace_back(byte);
+        code.push_back(al, byte);
     } while (n != 0);
-    return out;
 }
 
-void emit_signed_leb128(Vec<uint8_t> &code, Allocator &al, int32_t n) {
-    auto more = true;
+void emit_leb128_i32(Vec<uint8_t> &code, Allocator &al, int32_t n) { // for i32
+    bool more = true;
     do {
         uint8_t byte = n & 0x7f;
         n >>= 7;
@@ -49,15 +38,34 @@ void emit_signed_leb128(Vec<uint8_t> &code, Allocator &al, int32_t n) {
     } while (more);
 }
 
-void emit_unsigned_leb128(Vec<uint8_t> &code, Allocator &al, uint32_t n) {
+void emit_leb128_i64(Vec<uint8_t> &code, Allocator &al, int64_t n) { // for i64
+    bool more = true;
     do {
         uint8_t byte = n & 0x7f;
         n >>= 7;
-        if (n != 0) {
+        more = !((((n == 0) && ((byte & 0x40) == 0)) ||
+                  ((n == -1) && ((byte & 0x40) != 0))));
+        if (more) {
             byte |= 0x80;
         }
         code.push_back(al, byte);
-    } while (n != 0);
+    } while (more);
+}
+
+void emit_ieee754_f32(Vec<uint8_t> &code, Allocator &al, float z) { // for f32
+    uint8_t encoded_float[sizeof(z)];
+    std::memcpy(&encoded_float, &z, sizeof(z));
+    for(auto &byte:encoded_float){
+        code.push_back(al, byte);
+    }
+}
+
+void emit_ieee754_f64(Vec<uint8_t> &code, Allocator &al, double z) { // for f64
+    uint8_t encoded_float[sizeof(z)];
+    std::memcpy(&encoded_float, &z, sizeof(z));
+    for(auto &byte:encoded_float){
+        code.push_back(al, byte);
+    }
 }
 
 // function to emit header of Wasm Binary Format
@@ -72,28 +80,54 @@ void emit_header(Vec<uint8_t> &code, Allocator &al) {
     code.push_back(al, 0x00);
 }
 
-// function to emit unsigned 32 bit integer
-void emit_u32(Vec<uint8_t> &code, Allocator &al, uint32_t x) {
-    emit_unsigned_leb128(code, al, x);
-}
-
-// function to emit signed 32 bit integer
-void emit_i32(Vec<uint8_t> &code, Allocator &al, int32_t x) {
-    emit_signed_leb128(code, al, x);
-}
-
 // function to append a given bytecode to the end of the code
 void emit_b8(Vec<uint8_t> &code, Allocator &al, uint8_t x) {
     code.push_back(al, x);
 }
 
-void emit_u32_b32_idx(Vec<uint8_t> &code, uint32_t idx,
+// function to emit unsigned 32 bit integer
+void emit_u32(Vec<uint8_t> &code, Allocator &al, uint32_t x) {
+    emit_leb128_u32(code, al, x);
+}
+
+// function to emit signed 32 bit integer
+void emit_i32(Vec<uint8_t> &code, Allocator &al, int32_t x) {
+    emit_leb128_i32(code, al, x);
+}
+
+// function to emit signed 64 bit integer
+void emit_i64(Vec<uint8_t> &code, Allocator &al, int64_t x) {
+    emit_leb128_i64(code, al, x);
+}
+
+// function to emit 32 bit float
+void emit_f32(Vec<uint8_t> &code, Allocator &al, float x) {
+    emit_ieee754_f32(code, al, x);
+}
+
+// function to emit 64 bit float
+void emit_f64(Vec<uint8_t> &code, Allocator &al, double x) {
+    emit_ieee754_f64(code, al, x);
+}
+
+// function to emit string
+void emit_str(Vec<uint8_t> &code, Allocator &al, std::string text){
+    std::vector<uint8_t> text_bytes(text.size());
+    std::memcpy(text_bytes.data(), text.data(), text.size());
+    emit_u32(code, al, text_bytes.size());
+    for(auto &byte:text_bytes)
+        emit_b8(code, al, byte);
+}
+
+void emit_u32_b32_idx(Vec<uint8_t> &code, Allocator &al, uint32_t idx,
                       uint32_t section_size) {
     /*
     Encodes the integer `i` using LEB128 and adds trailing zeros to always
     occupy 4 bytes. Stores the int `i` at the index `idx` in `code`.
     */
-    std::vector<uint8_t> num = encode_unsigned_leb128(section_size);
+    Vec<uint8_t> num;
+    num.reserve(al, 4);
+    emit_leb128_u32(num, al, section_size);
     std::vector<uint8_t> num_4b = {0x80, 0x80, 0x80, 0x00};
     assert(num.size() <= 4);
     for (uint32_t i = 0; i < num.size(); i++) {
@@ -105,9 +139,9 @@ void emit_u32_b32_idx(Vec<uint8_t> &code, uint32_t idx,
 }
 
 // function to fixup length at the given length index
-void fixup_len(Vec<uint8_t> &code, uint32_t len_idx) {
+void fixup_len(Vec<uint8_t> &code, Allocator &al, uint32_t len_idx) {
     uint32_t section_len = code.size() - len_idx - 4u;
-    emit_u32_b32_idx(code, len_idx, section_len);
+    emit_u32_b32_idx(code, al, len_idx, section_len);
 }
 
 // function to emit length placeholder
@@ -120,15 +154,39 @@ uint32_t emit_len_placeholder(Vec<uint8_t> &code, Allocator &al) {
     return len_idx;
 }
 
-// function to emit a i32.const instruction
-void emit_i32_const(Vec<uint8_t> &code, Allocator &al, int32_t x) {
-    code.push_back(al, 0x41);
-    emit_i32(code, al, x);
+void emit_export_fn(Vec<uint8_t> &code, Allocator &al, const std::string& name,
+                    uint32_t idx) {
+    emit_str(code, al, name);
+    emit_b8(code, al, 0x00); // for exporting function
+    emit_u32(code, al, idx);
 }
 
-// function to emit end of wasm expression
-void emit_expr_end(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x0B);
+void emit_import_fn(Vec<uint8_t> &code, Allocator &al, const std::string &mod_name,
+                const std::string& fn_name, uint32_t type_idx) 
+{
+    emit_str(code, al, mod_name);
+    emit_str(code, al, fn_name);
+    emit_b8(code, al, 0x00); // for importing function
+    emit_u32(code, al, type_idx);
+}
+
+void emit_import_mem(Vec<uint8_t> &code, Allocator &al, const std::string &mod_name,
+                 const std::string& mem_name, uint32_t min_limit, uint32_t /* max_limit */) {
+    emit_str(code, al, mod_name);
+    emit_str(code, al, mem_name);
+    emit_b8(code, al, 0x02); // for importing memory
+    emit_b8(code, al, 0x00); // for specifying min page limit of memory
+    // max page limit can also be specifid, but currently omitting it.
+    emit_u32(code, al, min_limit);
+}
+
+void encode_section(Vec<uint8_t> &des, Vec<uint8_t> &section_content, Allocator &al, uint32_t section_id){
+    // every section in WebAssembly is encoded by adding its section id, followed by the content size and lastly the contents
+    emit_u32(des, al, section_id);
+    emit_u32(des, al, section_content.size());
+    for(auto &byte:section_content){
+        des.push_back(al, byte);
+    }
 }
 
 // function to emit get local variable at given index
@@ -143,57 +201,314 @@ void emit_set_local(Vec<uint8_t> &code, Allocator &al, uint32_t idx) {
     emit_u32(code, al, idx);
 }
 
-// function to emit i32.add instruction
-void emit_i32_add(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x6A);
-}
-
-// function to emit i32.sub instruction
-void emit_i32_sub(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x6B);
-}
-
-// function to emit i32.mul instruction
-void emit_i32_mul(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x6C);
-}
-
-// function to emit i32.div instruction
-void emit_i32_div(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x6D);
-}
-
-void emit_i64_add(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x7C);
-}
-
-void emit_i64_sub(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x7D);
-}
-
-void emit_i64_mul(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x7E);
-}
-
-void emit_i64_div(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x7F);
-}
-
 // function to emit call instruction
 void emit_call(Vec<uint8_t> &code, Allocator &al, uint32_t idx) {
     code.push_back(al, 0x10);
     emit_u32(code, al, idx);
 }
 
-void emit_export_fn(Vec<uint8_t> &code, Allocator &al, const std::string& name,
-                    uint32_t idx) {
-    std::vector<uint8_t> name_bytes(name.size());
-    std::memcpy(name_bytes.data(), name.data(), name.size());
-    emit_u32(code, al, name_bytes.size());
-    for(auto &byte:name_bytes)
-        emit_b8(code, al, byte);
-    emit_b8(code, al, 0x00);
-    emit_u32(code, al, idx);
+// function to emit end of wasm expression
+void emit_expr_end(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x0B);
+}
+
+/**************************** Integer Operations ****************************/
+
+// function to emit a i32.const instruction
+void emit_i32_const(Vec<uint8_t> &code, Allocator &al, int32_t x) {
+    code.push_back(al, 0x41);
+    emit_i32(code, al, x);
+}
+
+// function to emit i32.clz instruction
+void emit_i32_clz(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x67); }
+
+// function to emit i32.ctz instruction
+void emit_i32_ctz(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x68); }
+
+// function to emit i32.popcnt instruction
+void emit_i32_popcnt(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x69); }
+
+// function to emit i32.add instruction
+void emit_i32_add(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6A); }
+
+// function to emit i32.sub instruction
+void emit_i32_sub(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6B); }
+
+// function to emit i32.mul instruction
+void emit_i32_mul(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6C); }
+
+// function to emit i32.div_s instruction
+void emit_i32_div_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6D); }
+
+// function to emit i32.div_u instruction
+void emit_i32_div_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6E); }
+
+// function to emit i32.rem_s instruction
+void emit_i32_rem_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6F); }
+
+// function to emit i32.rem_u instruction
+void emit_i32_rem_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x70); }
+
+// function to emit i32.and instruction
+void emit_i32_and(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x71); }
+
+// function to emit i32.or instruction
+void emit_i32_or(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x72); }
+
+// function to emit i32.xor instruction
+void emit_i32_xor(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x73); }
+
+// function to emit i32.shl instruction
+void emit_i32_shl(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x74); }
+
+// function to emit i32.shr_s instruction
+void emit_i32_shr_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x75); }
+
+// function to emit i32.shr_u instruction
+void emit_i32_shr_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x76); }
+
+// function to emit i32.rotl instruction
+void emit_i32_rotl(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x77); }
+
+// function to emit i32.rotr instruction
+void emit_i32_rotr(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x78); }
+
+
+// function to emit a i64.const instruction
+void emit_i64_const(Vec<uint8_t> &code, Allocator &al, int64_t x) {
+    code.push_back(al, 0x42);
+    emit_i64(code, al, x);
+}
+
+// function to emit i64.clz instruction
+void emit_i64_clz(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x79); }
+
+// function to emit i64.ctz instruction
+void emit_i64_ctz(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7A); }
+
+// function to emit i64.popcnt instruction
+void emit_i64_popcnt(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7B); }
+
+// function to emit i64.add instruction
+void emit_i64_add(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7C); }
+
+// function to emit i64.sub instruction
+void emit_i64_sub(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7D); }
+
+// function to emit i64.mul instruction
+void emit_i64_mul(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7E); }
+
+// function to emit i64.div_s instruction
+void emit_i64_div_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7F); }
+
+// function to emit i64.div_u instruction
+void emit_i64_div_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x80); }
+
+// function to emit i64.rem_s instruction
+void emit_i64_rem_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x81); }
+
+// function to emit i64.rem_u instruction
+void emit_i64_rem_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x82); }
+
+// function to emit i64.and instruction
+void emit_i64_and(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x83); }
+
+// function to emit i64.or instruction
+void emit_i64_or(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x84); }
+
+// function to emit i64.xor instruction
+void emit_i64_xor(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x85); }
+
+// function to emit i64.shl instruction
+void emit_i64_shl(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x86); }
+
+// function to emit i64.shr_s instruction
+void emit_i64_shr_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x87); }
+
+// function to emit i64.shr_u instruction
+void emit_i64_shr_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x88); }
+
+// function to emit i64.rotl instruction
+void emit_i64_rotl(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x89); }
+
+// function to emit i64.rotr instruction
+void emit_i64_rotr(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8A); }
+
+
+
+/**************************** Floating Point Operations ****************************/
+
+// function to emit a f32.const instruction
+void emit_f32_const(Vec<uint8_t> &code, Allocator &al, float x) {
+    code.push_back(al, 0x43);
+    emit_f32(code, al, x);
+}
+
+// function to emit f32.abs instruction
+void emit_f32_abs(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8B); }
+
+// function to emit f32.neg instruction
+void emit_f32_neg(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8C); }
+
+// function to emit f32.ceil instruction
+void emit_f32_ceil(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8D); }
+
+// function to emit f32.floor instruction
+void emit_f32_floor(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8E); }
+
+// function to emit f32.trunc instruction
+void emit_f32_trunc(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8F); }
+
+// function to emit f32.nearest instruction
+void emit_f32_nearest(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x90); }
+
+// function to emit f32.sqrt instruction
+void emit_f32_sqrt(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x91); }
+
+// function to emit f32.add instruction
+void emit_f32_add(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x92); }
+
+// function to emit f32.sub instruction
+void emit_f32_sub(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x93); }
+
+// function to emit f32.mul instruction
+void emit_f32_mul(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x94); }
+
+// function to emit f32.div instruction
+void emit_f32_div(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x95); }
+
+// function to emit f32.min instruction
+void emit_f32_min(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x96); }
+
+// function to emit f32.max instruction
+void emit_f32_max(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x97); }
+
+// function to emit f32.copysign instruction
+void emit_f32_copysign(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x98); }
+
+
+// function to emit a f64.const instruction
+void emit_f64_const(Vec<uint8_t> &code, Allocator &al, double x) {
+    code.push_back(al, 0x44);
+    emit_f64(code, al, x);
+}
+
+// function to emit f64.abs instruction
+void emit_f64_abs(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x99); }
+
+// function to emit f64.neg instruction
+void emit_f64_neg(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9A); }
+
+// function to emit f64.ceil instruction
+void emit_f64_ceil(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9B); }
+
+// function to emit f64.floor instruction
+void emit_f64_floor(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9C); }
+
+// function to emit f64.trunc instruction
+void emit_f64_trunc(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9D); }
+
+// function to emit f64.nearest instruction
+void emit_f64_nearest(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9E); }
+
+// function to emit f64.sqrt instruction
+void emit_f64_sqrt(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9F); }
+
+// function to emit f64.add instruction
+void emit_f64_add(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA0); }
+
+// function to emit f64.sub instruction
+void emit_f64_sub(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA1); }
+
+// function to emit f64.mul instruction
+void emit_f64_mul(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA2); }
+
+// function to emit f64.div instruction
+void emit_f64_div(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA3); }
+
+// function to emit f64.min instruction
+void emit_f64_min(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA4); }
+
+// function to emit f64.max instruction
+void emit_f64_max(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA5); }
+
+// function to emit f64.copysign instruction
+void emit_f64_copysign(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA6); }
+
+
+// function to emit string
+void emit_str_const(Vec<uint8_t> &code, Allocator &al, uint32_t mem_idx, const std::string &text) {
+    emit_u32(code, al, 0U); // for active mode of memory with default mem_idx of 0
+    emit_i32_const(code, al, (int32_t)mem_idx); // specifying memory location as instructions
+    emit_expr_end(code, al); // end instructions
+    emit_str(code, al, text);
+}
+
+
+void emit_unreachable(Vec<uint8_t> &code, Allocator &al){
+    code.push_back(al, 0x00);
+}
+
+void save_js_glue(std::string filename){
+    std::string js_glue = 
+R"(function define_imports(memory, outputBuffer, stdout_print) {
+    const printNum = (num) => outputBuffer.push(num.toString());
+    const printStr = (startIdx, strSize) => outputBuffer.push(
+        new TextDecoder("utf8").decode(new Uint8Array(memory.buffer, startIdx, strSize)));
+    const flushBuffer = () => {
+        stdout_print(outputBuffer.join(" ") + "\n");
+        outputBuffer.length = 0;
+    }
+    var imports = {
+        js: {
+            memory: memory,
+            /* functions */
+            print_i32: printNum,
+            print_i64: printNum,
+            print_f32: printNum,
+            print_f64: printNum,
+            print_str: printStr,
+            flush_buf: flushBuffer,
+        },
+    };
+    return imports;
+}
+
+async function run_wasm(bytes, imports) {
+    var res;
+    try { res = await WebAssembly.instantiate(bytes, imports); }
+    catch (e) { console.log(e); return 1 /* non-zero return value */; }
+    const { _lcompilers_main } = res.instance.exports;
+    try { _lcompilers_main() }
+    catch (e) { return 1; }
+    return 0;
+}
+
+async function execute_code(bytes, stdout_print) {
+    var outputBuffer = [];
+    var memory = new WebAssembly.Memory({ initial: 10, maximum: 100 }); // initial 640Kb and max 6.4Mb
+    var imports = define_imports(memory, outputBuffer, stdout_print);
+    const exec_status = await run_wasm(bytes, imports);
+    return (exec_status ? outputBuffer[0] : 0); // the last element denotes the actual execution status
+}
+
+const fs = require("fs");
+const wasmBuffer = fs.readFileSync(")" + filename + 
+R"(");
+execute_code(wasmBuffer, (text) => process.stdout.write(text)).then().catch((e) => console.log(e))
+)";
+    filename += ".js";
+    std::ofstream out(filename);
+    out << js_glue;
+    out.close();
+}
+
+void save_bin(Vec<uint8_t> &code, std::string filename){
+    std::ofstream out(filename);
+    out.write((const char*) code.p, code.size());
+    out.close();
+    save_js_glue(filename);
 }
 
 }  // namespace wasm

--- a/src/libasr/codegen/wasm_to_wat.cpp
+++ b/src/libasr/codegen/wasm_to_wat.cpp
@@ -27,7 +27,7 @@ void WASMDecoder::load_file(std::string filename) {
 
 void WASMDecoder::decode_type_section(uint32_t offset) {
     // read type section contents
-    uint32_t no_of_func_types = read_unsigned_num(wasm_bytes, offset);
+    uint32_t no_of_func_types = read_u32(wasm_bytes, offset);
     DEBUG("no_of_func_types: " + std::to_string(no_of_func_types));
     func_types.resize(al, no_of_func_types);
 
@@ -38,71 +38,120 @@ void WASMDecoder::decode_type_section(uint32_t offset) {
         offset++;
 
         // read result type 1
-        uint32_t no_of_params = read_unsigned_num(wasm_bytes, offset);
+        uint32_t no_of_params = read_u32(wasm_bytes, offset);
         func_types.p[i].param_types.resize(al, no_of_params);
 
         for (uint32_t j = 0; j < no_of_params; j++) {
-            func_types.p[i].param_types.p[j] = wasm_bytes[offset++];
+            func_types.p[i].param_types.p[j] = read_b8(wasm_bytes, offset);
         }
 
-        uint32_t no_of_results = read_unsigned_num(wasm_bytes, offset);
+        uint32_t no_of_results = read_u32(wasm_bytes, offset);
         func_types.p[i].result_types.resize(al, no_of_results);
 
         for (uint32_t j = 0; j < no_of_results; j++) {
-            func_types.p[i].result_types.p[j] = wasm_bytes[offset++];
+            func_types.p[i].result_types.p[j] = read_b8(wasm_bytes, offset);
+        }
+    }
+}
+
+void WASMDecoder::decode_imports_section(uint32_t offset) {
+    // read imports section contents
+    uint32_t no_of_imports = read_u32(wasm_bytes, offset);
+    DEBUG("no_of_imports: " + std::to_string(no_of_imports));
+    imports.resize(al, no_of_imports);
+
+    for (uint32_t i = 0; i < no_of_imports; i++) {
+        uint32_t mod_name_size = read_u32(wasm_bytes, offset);
+        imports.p[i].mod_name.resize(mod_name_size); // do not pass al to this resize as it is std::string.resize()
+        for (uint32_t j = 0; j < mod_name_size; j++) {
+            imports.p[i].mod_name[j] = read_b8(wasm_bytes, offset);
+        }
+        
+        uint32_t name_size = read_u32(wasm_bytes, offset);
+        imports.p[i].name.resize(name_size); // do not pass al to this resize as it is std::string.resize()
+        for (uint32_t j = 0; j < name_size; j++) {
+            imports.p[i].name[j] = read_b8(wasm_bytes, offset);
+        }
+
+        imports.p[i].kind = read_b8(wasm_bytes, offset);
+
+        switch (imports.p[i].kind)
+        {
+            case 0x00: {
+                imports.p[i].type_idx = read_u32(wasm_bytes, offset);
+                break;
+            }
+            case 0x02: {
+                uint8_t byte = read_b8(wasm_bytes, offset);
+                if(byte == 0x00){
+                    imports.p[i].mem_page_size_limits.first = read_u32(wasm_bytes, offset);
+                    imports.p[i].mem_page_size_limits.second = imports.p[i].mem_page_size_limits.first;
+                }
+                else {
+                    LFORTRAN_ASSERT(byte == 0x01);
+                    imports.p[i].mem_page_size_limits.first = read_u32(wasm_bytes, offset);
+                    imports.p[i].mem_page_size_limits.second = read_u32(wasm_bytes, offset);
+                }
+                break;
+            }
+            
+            default: {
+                std::cout << "Only importing functions and memory are currently supported" << std::endl;
+                LFORTRAN_ASSERT(false);
+            }
         }
     }
 }
 
 void WASMDecoder::decode_function_section(uint32_t offset) {
     // read function section contents
-    uint32_t no_of_indices = read_unsigned_num(wasm_bytes, offset);
+    uint32_t no_of_indices = read_u32(wasm_bytes, offset);
     DEBUG("no_of_indices: " + std::to_string(no_of_indices));
     type_indices.resize(al, no_of_indices);
 
     for (uint32_t i = 0; i < no_of_indices; i++) {
-        type_indices.p[i] = read_unsigned_num(wasm_bytes, offset);
+        type_indices.p[i] = read_u32(wasm_bytes, offset);
     }
 }
 
 void WASMDecoder::decode_export_section(uint32_t offset) {
     // read export section contents
-    uint32_t no_of_exports = read_unsigned_num(wasm_bytes, offset);
+    uint32_t no_of_exports = read_u32(wasm_bytes, offset);
     DEBUG("no_of_exports: " + std::to_string(no_of_exports));
     exports.resize(al, no_of_exports);
 
     for (uint32_t i = 0; i < no_of_exports; i++) {
-        uint32_t name_size = read_unsigned_num(wasm_bytes, offset);
+        uint32_t name_size = read_u32(wasm_bytes, offset);
         exports.p[i].name.resize(name_size); // do not pass al to this resize as it is std::string.resize()
         for (uint32_t j = 0; j < name_size; j++) {
-            exports.p[i].name[j] = wasm_bytes[offset++];
+            exports.p[i].name[j] = read_b8(wasm_bytes, offset);
         }
         DEBUG("export name: " + exports.p[i].name);
-        exports.p[i].kind = wasm_bytes[offset++];
+        exports.p[i].kind = read_b8(wasm_bytes, offset);
         DEBUG("export kind: " + std::to_string(exports.p[i].kind));
-        exports.p[i].index = read_unsigned_num(wasm_bytes, offset);
+        exports.p[i].index = read_u32(wasm_bytes, offset);
         DEBUG("export index: " + std::to_string(exports.p[i].index));
     }
 }
 
 void WASMDecoder::decode_code_section(uint32_t offset) {
     // read code section contents
-    uint32_t no_of_codes = read_unsigned_num(wasm_bytes, offset);
+    uint32_t no_of_codes = read_u32(wasm_bytes, offset);
     DEBUG("no_of_codes: " + std::to_string(no_of_codes));
     codes.resize(al, no_of_codes);
 
     for (uint32_t i = 0; i < no_of_codes; i++) {
-        codes.p[i].size = read_unsigned_num(wasm_bytes, offset);
+        codes.p[i].size = read_u32(wasm_bytes, offset);
         uint32_t code_start_offset = offset;
-        uint32_t no_of_locals = read_unsigned_num(wasm_bytes, offset);
+        uint32_t no_of_locals = read_u32(wasm_bytes, offset);
         DEBUG("no_of_locals: " + std::to_string(no_of_locals));
         codes.p[i].locals.resize(al, no_of_locals);
 
         DEBUG("Entering loop");
         for (uint32_t j = 0U; j < no_of_locals; j++) {
-            codes.p[i].locals.p[j].count = read_unsigned_num(wasm_bytes, offset);
+            codes.p[i].locals.p[j].count = read_u32(wasm_bytes, offset);
             DEBUG("count: " + std::to_string(codes.p[i].locals.p[j].count));
-            codes.p[i].locals.p[j].type = wasm_bytes[offset++];
+            codes.p[i].locals.p[j].type = read_b8(wasm_bytes, offset);
             DEBUG("type: " + std::to_string(codes.p[i].locals.p[j].type));
         }
         DEBUG("Exiting loop");
@@ -114,17 +163,48 @@ void WASMDecoder::decode_code_section(uint32_t offset) {
     }
 }
 
+void WASMDecoder::decode_data_section(uint32_t offset) {
+    // read code section contents
+    uint32_t no_of_data_segments = read_u32(wasm_bytes, offset);
+    DEBUG("no_of_data_segments: " + std::to_string(no_of_data_segments));
+    data_segments.resize(al, no_of_data_segments);
+
+    for (uint32_t i = 0; i < no_of_data_segments; i++) {
+        uint32_t num = read_u32(wasm_bytes, offset);
+        if(num != 0){
+            throw LFortran::LFortranException("Only active default memory (index = 0) is currently supported");
+        }
+
+        {
+            WASM_INSTS_VISITOR::WATVisitor v = WASM_INSTS_VISITOR::WATVisitor(wasm_bytes, offset, "", "");
+            v.decode_instructions();
+            data_segments.p[i].insts = v.src;
+            offset = v.offset;
+        }
+
+        uint32_t text_size = read_u32(wasm_bytes, offset);
+        data_segments.p[i].text.resize(text_size); // do not pass al to this resize as it is std::string.resize()
+        for (uint32_t j = 0; j < text_size; j++) {
+            data_segments.p[i].text[j] = read_b8(wasm_bytes, offset);
+        }
+    }
+}
+
 void WASMDecoder::decode_wasm() {
     // first 8 bytes are magic number and wasm version number
     // currently, in this first version, we are skipping them
     uint32_t index = 8U;
 
     while (index < wasm_bytes.size()) {
-        uint32_t section_id = read_unsigned_num(wasm_bytes, index);
-        uint32_t section_size = read_unsigned_num(wasm_bytes, index);
+        uint32_t section_id = read_u32(wasm_bytes, index);
+        uint32_t section_size = read_u32(wasm_bytes, index);
         switch (section_id) {
             case 1U:
                 decode_type_section(index);
+                // exit(0);
+                break;
+            case 2U:
+                decode_imports_section(index);
                 // exit(0);
                 break;
             case 3U:
@@ -137,6 +217,10 @@ void WASMDecoder::decode_wasm() {
                 break;
             case 10U:
                 decode_code_section(index);
+                // exit(0)
+                break;
+            case 11U:
+                decode_data_section(index);
                 // exit(0)
                 break;
             default:
@@ -152,10 +236,33 @@ void WASMDecoder::decode_wasm() {
 
 std::string WASMDecoder::get_wat() {
     std::string result = "(module";
+    std::string indent = "\n    ";
+    for(uint32_t i = 0U; i < func_types.size(); i++){
+        result += indent + "(type (;" + std::to_string(i)+ ";) (func (param";
+        for (uint32_t j = 0; j < func_types[i].param_types.size(); j++) {
+            result += " " + var_type_to_string[func_types[i].param_types.p[j]];
+        }
+        result += ") (result";
+        for (uint32_t j = 0; j < func_types[i].result_types.size(); j++) {
+            result += " " + var_type_to_string[func_types[i].result_types.p[j]];
+        }
+        result += ")))";
+    }
+
+    for(uint32_t i = 0; i < imports.size(); i++){
+        result += indent + "(import \"" + imports[i].mod_name + "\" \"" + imports[i].name + "\" ";
+        if(imports[i].kind == 0x00){
+            result += "(func (;" + std::to_string(i) + ";) (type " + std::to_string(imports[i].type_idx) + ")))";
+        }
+        else if(imports[i].kind == 0x02){
+            result += "(memory (;0;) " + std::to_string(imports[i].mem_page_size_limits.first) + "))";
+        }
+    }
+
     for (uint32_t i = 0; i < type_indices.size(); i++) {
-        result += "\n    (func $" + std::to_string(i);
-        result += "\n        (param";
         uint32_t func_index = type_indices.p[i];
+        result += indent + "(func $" + std::to_string(func_index);
+        result += " (type " + std::to_string(func_index) + ") (param";
         for (uint32_t j = 0; j < func_types[func_index].param_types.size(); j++) {
             result += " " + var_type_to_string[func_types[func_index].param_types.p[j]];
         }
@@ -164,7 +271,7 @@ std::string WASMDecoder::get_wat() {
             result += " " + var_type_to_string[func_types[func_index].result_types.p[j]];
         }
         result += ")";
-        result += "\n        (local";
+        result += indent + "    (local";
         for (uint32_t j = 0; j < codes.p[i].locals.size(); j++) {
             for (uint32_t k = 0; k < codes.p[i].locals.p[j].count; k++) {
                 result += " " + var_type_to_string[codes.p[i].locals.p[j].type];
@@ -173,18 +280,22 @@ std::string WASMDecoder::get_wat() {
         result += ")";
 
         {
-            WASM_INSTS_VISITOR::WATVisitor v = WASM_INSTS_VISITOR::WATVisitor();
-            v.indent = "\n        ";
-            v.decode_instructions(wasm_bytes, codes.p[i].insts_start_index);
+            WASM_INSTS_VISITOR::WATVisitor v = WASM_INSTS_VISITOR::WATVisitor(wasm_bytes, codes.p[i].insts_start_index, "", indent + "    ");
+            v.decode_instructions();
             result += v.src;
         }
 
-        result += "\n    )";
+        result += indent + ")";
     }
 
     for (uint32_t i = 0; i < exports.size(); i++) {
-        result += "\n    (export \"" + exports.p[i].name + "\" (" + kind_to_string[exports.p[i].kind] + " $" + std::to_string(exports.p[i].index) + "))";
+        result += indent + "(export \"" + exports.p[i].name + "\" (" + kind_to_string[exports.p[i].kind] + " $" + std::to_string(exports.p[i].index) + "))";
     }
+
+    for(uint32_t i = 0; i < data_segments.size(); i++){
+        result += indent + "(data (;" + std::to_string(i) + ";) (" + data_segments[i].insts + ") \"" + data_segments[i].text + "\")"; 
+    }
+
     result += "\n)\n";
 
     return result;

--- a/src/libasr/codegen/wasm_to_wat.h
+++ b/src/libasr/codegen/wasm_to_wat.h
@@ -11,29 +11,49 @@ class WATVisitor : public BaseWASMVisitor<WATVisitor> {
    public:
     std::string src, indent;
 
-    WATVisitor() : src(""), indent("") {}
+    WATVisitor(Vec<uint8_t> &code, uint32_t offset, std::string src, std::string indent) : BaseWASMVisitor(code, offset), src(src), indent(indent) {}
 
+    void visit_Unreachable() { src += indent + "unreachable"; }
     void visit_Return() { src += indent + "return"; }
-
     void visit_Call(uint32_t func_index) { src += indent + "call " + std::to_string(func_index); }
-
     void visit_LocalGet(uint32_t localidx) { src += indent + "local.get " + std::to_string(localidx); }
-
     void visit_LocalSet(uint32_t localidx) { src += indent + "local.set " + std::to_string(localidx); }
+    void visit_EmtpyBlockType() {}
+    void visit_If() {
+        src += indent + "if";
+        {
+            WATVisitor v = WATVisitor(code, offset, "", indent + "    ");
+            v.decode_instructions();
+            src += v.src;
+            offset = v.offset;
+        }
+        src += indent + "end";
+    }
+    void visit_Else() { src += indent + "\b\b\b\b" + "else"; }
 
-    void visit_I32Const(int value) { src += indent + "i32.const " + std::to_string(value); }
-
+    void visit_I32Const(int32_t value) { src += indent + "i32.const " + std::to_string(value); }
     void visit_I32Add() { src += indent + "i32.add"; }
-    void visit_I64Add() { src += indent + "i64.add"; }
-
     void visit_I32Sub() { src += indent + "i32.sub"; }
-    void visit_I64Sub() { src += indent + "i64.sub"; }
-
     void visit_I32Mul() { src += indent + "i32.mul"; }
-    void visit_I64Mul() { src += indent + "i64.mul"; }
-
     void visit_I32DivS() { src += indent + "i32.div_s"; }
+
+    void visit_I64Const(int64_t value) { src += indent + "i64.const " + std::to_string(value); }
+    void visit_I64Add() { src += indent + "i64.add"; }
+    void visit_I64Sub() { src += indent + "i64.sub"; }
+    void visit_I64Mul() { src += indent + "i64.mul"; }
     void visit_I64DivS() { src += indent + "i64.div_s"; }
+
+    void visit_F32Const(float value) { src += indent + "f32.const " + std::to_string(value); }
+    void visit_F32Add() { src += indent + "f32.add"; }
+    void visit_F32Sub() { src += indent + "f32.sub"; }
+    void visit_F32Mul() { src += indent + "f32.mul"; }
+    void visit_F32DivS() { src += indent + "f32.div_s"; }
+    
+    void visit_F64Const(double value) { src += indent + "f64.const " + std::to_string(value); }
+    void visit_F64Add() { src += indent + "f64.add"; }
+    void visit_F64Sub() { src += indent + "f64.sub"; }
+    void visit_F64Mul() { src += indent + "f64.mul"; }
+    void visit_F64DivS() { src += indent + "f64.div_s"; }
 };
 
 }  // namespace WASM_INSTS_VISITOR
@@ -49,9 +69,11 @@ class WASMDecoder {
     Vec<uint8_t> wasm_bytes;
 
     Vec<wasm::FuncType> func_types;
+    Vec<wasm::Import> imports;
     Vec<uint32_t> type_indices;
     Vec<wasm::Export> exports;
     Vec<wasm::Code> codes;
+    Vec<wasm::Data> data_segments;
 
     WASMDecoder(Allocator &al) : al(al) {
         var_type_to_string = {{0x7F, "i32"}, {0x7E, "i64"}, {0x7D, "f32"}, {0x7C, "f64"}};
@@ -66,9 +88,11 @@ class WASMDecoder {
 
     void load_file(std::string filename);
     void decode_type_section(uint32_t offset);
+    void decode_imports_section(uint32_t offset);
     void decode_function_section(uint32_t offset);
     void decode_export_section(uint32_t offset);
     void decode_code_section(uint32_t offset);
+    void decode_data_section(uint32_t offset);
     void decode_wasm();
     std::string get_wat();
 };

--- a/src/libasr/codegen/wasm_utils.h
+++ b/src/libasr/codegen/wasm_utils.h
@@ -33,19 +33,36 @@ struct Code {
     uint32_t insts_start_index;
 };
 
-uint32_t decode_unsigned_leb128(Vec<uint8_t> &code, uint32_t &offset);
+struct Import {
+    std::string mod_name;
+    std::string name;
+    uint8_t kind;
+    union {
+        uint32_t type_idx;
+        std::pair<uint32_t, uint32_t> mem_page_size_limits;
+    };
+};
 
-int32_t decode_signed_leb128(Vec<uint8_t> &code, uint32_t &offset);
+struct Data {
+    std::string insts;
+    std::string text;
+};
 
-uint8_t read_byte(Vec<uint8_t> &code, uint32_t &offset);
+uint32_t decode_leb128_u32(Vec<uint8_t> &code, uint32_t &offset);
+int32_t decode_leb128_i32(Vec<uint8_t> &code, uint32_t &offset);
+int64_t decode_leb128_i64(Vec<uint8_t> &code, uint32_t &offset);
 
-float read_float(Vec<uint8_t> & code, uint32_t & offset);
+uint8_t read_b8(Vec<uint8_t> &code, uint32_t &offset);
 
-double read_double(Vec<uint8_t> & code, uint32_t & offset);
+float read_f32(Vec<uint8_t> & code, uint32_t & offset);
 
-int32_t read_signed_num(Vec<uint8_t> &code, uint32_t &offset);
+double read_f64(Vec<uint8_t> & code, uint32_t & offset);
 
-uint32_t read_unsigned_num(Vec<uint8_t> &code, uint32_t &offset);
+uint32_t read_u32(Vec<uint8_t> &code, uint32_t &offset);
+
+int32_t read_i32(Vec<uint8_t> &code, uint32_t &offset);
+
+int64_t read_i64(Vec<uint8_t> &code, uint32_t &offset);
 
 void hexdump(void *ptr, int buflen);
 

--- a/src/libasr/containers.h
+++ b/src/libasr/containers.h
@@ -180,6 +180,19 @@ struct Str {
 static_assert(std::is_standard_layout<Str>::value);
 static_assert(std::is_trivial<Str>::value);
 
+template <typename ...Args>
+std::string string_format(const std::string& format, Args && ...args)
+{
+    auto size = std::snprintf(nullptr, 0, format.c_str(), std::forward<Args>(args)...);
+    std::string output(size, '\0');
+    std::sprintf(&output[0], format.c_str(), std::forward<Args>(args)...);
+    return output;
+}
+
+static inline std::string double_to_scientific(double x) {
+    return string_format("%25.17e", x);
+}
+
 } // namespace LFortran
 
 

--- a/src/libasr/pass/arr_slice.cpp
+++ b/src/libasr/pass/arr_slice.cpp
@@ -79,18 +79,12 @@ public:
                 end = PassUtils::to_int32(end, int32_type, al);
                 step = PassUtils::to_int32(step, int32_type, al);
 
-                ASR::expr_t* gap = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, x.base.base.loc,
-                                                        end, ASR::binopType::Sub, start,
-                                                        int32_type, nullptr, nullptr));
-                // ASR::expr_t* slice_size = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, x.base.base.loc,
-                //                                                  gap, ASR::binopType::Add, const_1,
-                //                                                  int64_type, nullptr));
-                ASR::expr_t* slice_size = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, x.base.base.loc,
-                                                                gap, ASR::binopType::Div, step,
-                                                                int32_type, nullptr, nullptr));
-                ASR::expr_t* actual_size = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, x.base.base.loc,
-                                                                slice_size, ASR::binopType::Add, const_1,
-                                                                int32_type, nullptr, nullptr));
+                ASR::expr_t* gap = LFortran::ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, x.base.base.loc,
+                                                        end, ASR::binopType::Sub, start, int32_type, nullptr));
+                ASR::expr_t* slice_size = LFortran::ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, x.base.base.loc,
+                                                        gap, ASR::binopType::Div, step, int32_type, nullptr));
+                ASR::expr_t* actual_size = LFortran::ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, x.base.base.loc,
+                                                        slice_size, ASR::binopType::Add, const_1, int32_type, nullptr));
                 ASR::dimension_t curr_dim;
                 curr_dim.loc = x.base.base.loc;
                 curr_dim.m_start = const_1;
@@ -201,7 +195,7 @@ public:
                     doloop_body.push_back(al, set_to_one);
                     doloop_body.push_back(al, doloop);
                 }
-                ASR::expr_t* inc_expr = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, x.base.base.loc, idx_vars_target[i], ASR::binopType::Add, const_1, int32_type, nullptr, nullptr));
+                ASR::expr_t* inc_expr = LFortran::ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, x.base.base.loc, idx_vars_target[i], ASR::binopType::Add, const_1, int32_type, nullptr));
                 ASR::stmt_t* assign_stmt = LFortran::ASRUtils::STMT(ASR::make_Assignment_t(al, x.base.base.loc, idx_vars_target[i], inc_expr, nullptr));
                 doloop_body.push_back(al, assign_stmt);
                 doloop = LFortran::ASRUtils::STMT(ASR::make_DoLoop_t(al, x.base.base.loc, head, doloop_body.p, doloop_body.size()));
@@ -213,6 +207,10 @@ public:
     }
 
     void visit_Assignment(const ASR::Assignment_t& x) {
+        if( ASR::is_a<ASR::Pointer_t>(*ASRUtils::expr_type(x.m_target)) &&
+            ASR::is_a<ASR::GetPointer_t>(*x.m_value) ) {
+            return ;
+        }
         this->visit_expr(*x.m_value);
         // If any slicing happened then do loop must have been created
         // So, the current assignment should be inserted into pass_result
@@ -222,8 +220,22 @@ public:
         }
     }
 
-    void visit_BinOp(const ASR::BinOp_t& x) {
-        ASR::BinOp_t& xx = const_cast<ASR::BinOp_t&>(x);
+    void visit_IntegerBinOp(const ASR::IntegerBinOp_t& x) {
+        handle_BinOp(x);
+    }
+    void visit_RealBinOp(const ASR::RealBinOp_t& x) {
+        handle_BinOp(x);
+    }
+    void visit_ComplexBinOp(const ASR::ComplexBinOp_t& x) {
+        handle_BinOp(x);
+    }
+    void visit_LogicalBinOp(const ASR::LogicalBinOp_t& x) {
+        handle_BinOp(x);
+    }
+
+    template <typename T>
+    void handle_BinOp(const T& x) {
+        T& xx = const_cast<T&>(x);
         create_slice_var = true;
         slice_var = nullptr;
         this->visit_expr(*x.m_left);

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -232,6 +232,10 @@ public:
     }
 
     void visit_Assignment(const ASR::Assignment_t& x) {
+        if( ASR::is_a<ASR::Pointer_t>(*ASRUtils::expr_type(x.m_target)) &&
+            ASR::is_a<ASR::GetPointer_t>(*x.m_value) ) {
+            return ;
+        }
         if( PassUtils::is_array(x.m_target) ) {
             result_var = x.m_target;
             this->visit_expr(*(x.m_value));
@@ -421,11 +425,28 @@ public:
         }
     }
 
-    void visit_UnaryOp(const ASR::UnaryOp_t& x) {
+    void visit_IntegerUnaryMinus(const ASR::IntegerUnaryMinus_t &x) {
+        handle_UnaryOp(x, 0);
+    }
+    void visit_RealUnaryMinus(const ASR::RealUnaryMinus_t &x) {
+        handle_UnaryOp(x, 1);
+    }
+    void visit_ComplexUnaryMinus(const ASR::ComplexUnaryMinus_t &x) {
+        handle_UnaryOp(x, 2);
+    }
+    void visit_IntegerBitNot(const ASR::IntegerBitNot_t &x) {
+        handle_UnaryOp(x, 3);
+    }
+    void visit_LogicalNot(const ASR::LogicalNot_t &x) {
+        handle_UnaryOp(x, 4);
+    }
+
+    template<typename T>
+    void handle_UnaryOp(const T& x, int unary_type) {
         std::string res_prefix = "_unary_op_res";
         ASR::expr_t* result_var_copy = result_var;
         result_var = nullptr;
-        this->visit_expr(*(x.m_operand));
+        this->visit_expr(*(x.m_arg));
         ASR::expr_t* operand = tmp_val;
         int rank_operand = PassUtils::get_rank(operand);
         if( rank_operand == 0 ) {
@@ -458,9 +479,23 @@ public:
                 if( doloop == nullptr ) {
                     ASR::expr_t* ref = PassUtils::create_array_ref(operand, idx_vars, al);
                     ASR::expr_t* res = PassUtils::create_array_ref(result_var, idx_vars, al);
-                    ASR::expr_t* op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_UnaryOp_t(
-                                                    al, x.base.base.loc,
-                                                    x.m_op, ref, x.m_type, nullptr));
+                    ASR::expr_t* op_el_wise = nullptr;
+                    if (unary_type == 0) {
+                        op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_IntegerUnaryMinus_t(al, x.base.base.loc,
+                            ref, x.m_type, nullptr));
+                    } else if (unary_type == 1) {
+                        op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_RealUnaryMinus_t(al, x.base.base.loc,
+                            ref, x.m_type, nullptr));
+                    } else if (unary_type == 2) {
+                        op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_ComplexUnaryMinus_t(al, x.base.base.loc,
+                            ref, x.m_type, nullptr));
+                    } else if (unary_type == 3) {
+                        op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_IntegerBitNot_t(al, x.base.base.loc,
+                            ref, x.m_type, nullptr));
+                    } else if (unary_type == 4) {
+                        op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_LogicalNot_t(al, x.base.base.loc,
+                            ref, x.m_type, nullptr));
+                    }
                     ASR::stmt_t* assign = LFortran::ASRUtils::STMT(ASR::make_Assignment_t(al, x.base.base.loc, res, op_el_wise, nullptr));
                     doloop_body.push_back(al, assign);
                 } else {
@@ -531,21 +566,45 @@ public:
                     ASR::expr_t* res = PassUtils::create_array_ref(result_var, idx_vars, al);
                     ASR::expr_t* op_el_wise = nullptr;
                     switch( x.class_type ) {
-                        case ASR::exprType::BinOp:
-                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(
+                        case ASR::exprType::IntegerBinOp:
+                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
                                                 al, x.base.base.loc,
-                                                ref_1, (ASR::binopType)x.m_op, ref_2,
-                                                x.m_type, nullptr, nullptr));
+                                                ref_1, (ASR::binopType)x.m_op, ref_2, x.m_type, nullptr));
                             break;
-                        case ASR::exprType::Compare:
-                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_Compare_t(
+                        case ASR::exprType::RealBinOp:
+                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_RealBinOp_t(
                                                 al, x.base.base.loc,
-                                                ref_1, (ASR::cmpopType)x.m_op, ref_2, x.m_type, nullptr, nullptr));
+                                                ref_1, (ASR::binopType)x.m_op, ref_2, x.m_type, nullptr));
                             break;
-                        case ASR::exprType::BoolOp:
-                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_BoolOp_t(
+                        case ASR::exprType::ComplexBinOp:
+                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_ComplexBinOp_t(
                                                 al, x.base.base.loc,
-                                                ref_1, (ASR::boolopType)x.m_op, ref_2, x.m_type, nullptr));
+                                                ref_1, (ASR::binopType)x.m_op, ref_2, x.m_type, nullptr));
+                            break;
+                        case ASR::exprType::LogicalBinOp:
+                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_LogicalBinOp_t(
+                                                al, x.base.base.loc,
+                                                ref_1, (ASR::logicalbinopType)x.m_op, ref_2, x.m_type, nullptr));
+                            break;
+                       case ASR::exprType::IntegerCompare:
+                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_IntegerCompare_t(
+                                                    al, x.base.base.loc,
+                                                    ref_1, (ASR::cmpopType)x.m_op, ref_2, x.m_type, nullptr));
+                            break;
+                        case ASR::exprType::RealCompare:
+                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_RealCompare_t(
+                                                    al, x.base.base.loc,
+                                                    ref_1, (ASR::cmpopType)x.m_op, ref_2, x.m_type, nullptr));
+                            break;
+                        case ASR::exprType::ComplexCompare:
+                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_ComplexCompare_t(
+                                                    al, x.base.base.loc,
+                                                    ref_1, (ASR::cmpopType)x.m_op, ref_2, x.m_type, nullptr));
+                            break;
+                        case ASR::exprType::LogicalCompare:
+                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_LogicalCompare_t(
+                                                    al, x.base.base.loc,
+                                                    ref_1, (ASR::cmpopType)x.m_op, ref_2, x.m_type, nullptr));
                             break;
                         default:
                             throw LFortranException("The desired operation is not supported yet for arrays.");
@@ -557,9 +616,8 @@ public:
                     doloop_body.push_back(al, set_to_one);
                     doloop_body.push_back(al, doloop);
                 }
-                ASR::expr_t* inc_expr = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, x.base.base.loc, idx_vars_value[i],
-                                                                                   ASR::binopType::Add, const_1, int32_type,
-                                                                                   nullptr, nullptr));
+                ASR::expr_t* inc_expr = LFortran::ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, x.base.base.loc, idx_vars_value[i],
+                                                                ASR::binopType::Add, const_1, int32_type, nullptr));
                 ASR::stmt_t* assign_stmt = LFortran::ASRUtils::STMT(ASR::make_Assignment_t(al, x.base.base.loc, idx_vars_value[i], inc_expr, nullptr));
                 doloop_body.push_back(al, assign_stmt);
                 doloop = LFortran::ASRUtils::STMT(ASR::make_DoLoop_t(al, x.base.base.loc, head, doloop_body.p, doloop_body.size()));
@@ -614,21 +672,45 @@ public:
                     ASR::expr_t* res = PassUtils::create_array_ref(result_var, idx_vars, al);
                     ASR::expr_t* op_el_wise = nullptr;
                     switch( x.class_type ) {
-                        case ASR::exprType::BinOp:
-                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(
+                        case ASR::exprType::IntegerBinOp:
+                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
                                                     al, x.base.base.loc,
-                                                    ref, (ASR::binopType)x.m_op, other_expr,
-                                                    x.m_type, nullptr, nullptr));
+                                                    ref, (ASR::binopType)x.m_op, other_expr, x.m_type, nullptr));
                             break;
-                        case ASR::exprType::Compare:
-                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_Compare_t(
+                        case ASR::exprType::RealBinOp:
+                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_RealBinOp_t(
                                                     al, x.base.base.loc,
-                                                    ref, (ASR::cmpopType)x.m_op, other_expr, x.m_type, nullptr, nullptr));
+                                                    ref, (ASR::binopType)x.m_op, other_expr, x.m_type, nullptr));
                             break;
-                        case ASR::exprType::BoolOp:
-                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_BoolOp_t(
+                        case ASR::exprType::ComplexBinOp:
+                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_ComplexBinOp_t(
                                                     al, x.base.base.loc,
-                                                    ref, (ASR::boolopType)x.m_op, other_expr, x.m_type, nullptr));
+                                                    ref, (ASR::binopType)x.m_op, other_expr, x.m_type, nullptr));
+                            break;
+                        case ASR::exprType::LogicalBinOp:
+                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_LogicalBinOp_t(
+                                                    al, x.base.base.loc,
+                                                    ref, (ASR::logicalbinopType)x.m_op, other_expr, x.m_type, nullptr));
+                            break;
+                        case ASR::exprType::IntegerCompare:
+                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_IntegerCompare_t(
+                                                    al, x.base.base.loc,
+                                                    ref, (ASR::cmpopType)x.m_op, other_expr, x.m_type, nullptr));
+                            break;
+                        case ASR::exprType::RealCompare:
+                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_RealCompare_t(
+                                                    al, x.base.base.loc,
+                                                    ref, (ASR::cmpopType)x.m_op, other_expr, x.m_type, nullptr));
+                            break;
+                        case ASR::exprType::ComplexCompare:
+                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_ComplexCompare_t(
+                                                    al, x.base.base.loc,
+                                                    ref, (ASR::cmpopType)x.m_op, other_expr, x.m_type, nullptr));
+                            break;
+                        case ASR::exprType::LogicalCompare:
+                            op_el_wise = LFortran::ASRUtils::EXPR(ASR::make_LogicalCompare_t(
+                                                    al, x.base.base.loc,
+                                                    ref, (ASR::cmpopType)x.m_op, other_expr, x.m_type, nullptr));
                             break;
                         default:
                             throw LFortranException("The desired operation is not supported yet for arrays.");
@@ -640,7 +722,8 @@ public:
                     doloop_body.push_back(al, set_to_one);
                     doloop_body.push_back(al, doloop);
                 }
-                ASR::expr_t* inc_expr = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, x.base.base.loc, idx_vars_value[i], ASR::binopType::Add, const_1, int32_type, nullptr, nullptr));
+                ASR::expr_t* inc_expr = LFortran::ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, x.base.base.loc, idx_vars_value[i],
+                                                                ASR::binopType::Add, const_1, int32_type, nullptr));
                 ASR::stmt_t* assign_stmt = LFortran::ASRUtils::STMT(ASR::make_Assignment_t(al, x.base.base.loc, idx_vars_value[i], inc_expr, nullptr));
                 doloop_body.push_back(al, assign_stmt);
                 doloop = LFortran::ASRUtils::STMT(ASR::make_DoLoop_t(al, x.base.base.loc, head, doloop_body.p, doloop_body.size()));
@@ -651,16 +734,36 @@ public:
         }
     }
 
-    void visit_BinOp(const ASR::BinOp_t &x) {
-        visit_ArrayOpCommon<ASR::BinOp_t>(x, "_bin_op_res");
+    void visit_IntegerBinOp(const ASR::IntegerBinOp_t &x) {
+        visit_ArrayOpCommon<ASR::IntegerBinOp_t>(x, "_bin_op_res");
     }
 
-    void visit_Compare(const ASR::Compare_t &x) {
-        visit_ArrayOpCommon<ASR::Compare_t>(x, "_comp_op_res");
+    void visit_RealBinOp(const ASR::RealBinOp_t &x) {
+        visit_ArrayOpCommon<ASR::RealBinOp_t>(x, "_bin_op_res");
     }
 
-    void visit_BoolOp(const ASR::BoolOp_t &x) {
-        visit_ArrayOpCommon<ASR::BoolOp_t>(x, "_bool_op_res");
+    void visit_ComplexBinOp(const ASR::ComplexBinOp_t &x) {
+        visit_ArrayOpCommon<ASR::ComplexBinOp_t>(x, "_bin_op_res");
+    }
+
+    void visit_LogicalBinOp(const ASR::LogicalBinOp_t &x) {
+        visit_ArrayOpCommon<ASR::LogicalBinOp_t>(x, "_bool_op_res");
+    }
+
+    void visit_IntegerCompare(const ASR::IntegerCompare_t &x) {
+        visit_ArrayOpCommon<ASR::IntegerCompare_t>(x, "_comp_op_res");
+    }
+
+    void visit_RealCompare(const ASR::RealCompare_t &x) {
+        visit_ArrayOpCommon<ASR::RealCompare_t>(x, "_comp_op_res");
+    }
+
+    void visit_ComplexCompare(const ASR::ComplexCompare_t &x) {
+        visit_ArrayOpCommon<ASR::ComplexCompare_t>(x, "_comp_op_res");
+    }
+
+    void visit_LogicalCompare(const ASR::LogicalCompare_t &x) {
+        visit_ArrayOpCommon<ASR::LogicalCompare_t>(x, "_comp_op_res");
     }
 
     void visit_ArraySize(const ASR::ArraySize_t& x) {

--- a/src/libasr/pass/class_constructor.cpp
+++ b/src/libasr/pass/class_constructor.cpp
@@ -21,11 +21,34 @@ private:
 
 public:
 
-    bool is_constructor_present;
+    bool is_constructor_present, is_init_constructor;
 
     ClassConstructorVisitor(Allocator &al) : PassVisitor(al, nullptr),
-    result_var(nullptr), is_constructor_present(false) {
+    result_var(nullptr), is_constructor_present(false),
+    is_init_constructor(false) {
         pass_result.reserve(al, 0);
+    }
+
+    void visit_Subroutine(const ASR::Subroutine_t &x) {
+        // FIXME: this is a hack, we need to pass in a non-const `x`,
+        // which requires to generate a TransformVisitor.
+        ASR::Subroutine_t &xx = const_cast<ASR::Subroutine_t&>(x);
+        current_scope = xx.m_symtab;
+        for( auto item: current_scope->get_scope() ) {
+            if( ASR::is_a<ASR::Variable_t>(*item.second) ) {
+                ASR::Variable_t* variable = ASR::down_cast<ASR::Variable_t>(item.second);
+                if( variable->m_symbolic_value ) {
+                    result_var = ASRUtils::EXPR(ASR::make_Var_t(al, variable->base.base.loc,
+                                                                item.second));
+                    is_init_constructor = false;
+                    this->visit_expr(*variable->m_symbolic_value);
+                    if( is_init_constructor ) {
+                        variable->m_symbolic_value = nullptr;
+                    }
+                }
+            }
+        }
+        transform_stmts(xx.m_body, xx.n_body);
     }
 
     void visit_Assignment(const ASR::Assignment_t& x) {
@@ -37,10 +60,14 @@ public:
     }
 
     void visit_DerivedTypeConstructor(const ASR::DerivedTypeConstructor_t &x) {
+        is_init_constructor = true;
+        if( x.n_args == 0 ) {
+            remove_original_stmt = true;
+        }
         ASR::Derived_t* dt_der = down_cast<ASR::Derived_t>(x.m_type);
-        ASR::DerivedType_t* dt_dertype = (ASR::DerivedType_t*)(&(
-                                         LFortran::ASRUtils::symbol_get_past_external(dt_der->m_derived_type)->base));
-        for( size_t i = 0; i < dt_dertype->n_members; i++ ) {
+        ASR::DerivedType_t* dt_dertype = ASR::down_cast<ASR::DerivedType_t>(
+                                         LFortran::ASRUtils::symbol_get_past_external(dt_der->m_derived_type));
+        for( size_t i = 0; i < std::min(dt_dertype->n_members, x.n_args); i++ ) {
             ASR::symbol_t* member = dt_dertype->m_symtab->resolve_symbol(std::string(dt_dertype->m_members[i], strlen(dt_dertype->m_members[i])));
             ASR::expr_t* derived_ref = LFortran::ASRUtils::EXPR(ASRUtils::getDerivedRef_t(al, x.base.base.loc, (ASR::asr_t*)result_var, member, current_scope));
             ASR::stmt_t* assign = LFortran::ASRUtils::STMT(ASR::make_Assignment_t(al, x.base.base.loc, derived_ref, x.m_args[i], nullptr));

--- a/src/libasr/pass/div_to_mul.cpp
+++ b/src/libasr/pass/div_to_mul.cpp
@@ -46,7 +46,7 @@ public:
         pass_result.reserve(al, 1);
     }
 
-    void visit_BinOp(const ASR::BinOp_t& x) {
+    void visit_RealBinOp(const ASR::RealBinOp_t& x) {
         visit_expr(*x.m_left);
         visit_expr(*x.m_right);
         if( x.m_op == ASR::binopType::Div ) {
@@ -66,7 +66,7 @@ public:
                             break;
                     }
                     if( is_feasible ) {
-                        ASR::BinOp_t& xx = const_cast<ASR::BinOp_t&>(x);
+                        ASR::RealBinOp_t& xx = const_cast<ASR::RealBinOp_t&>(x);
                         xx.m_op = ASR::binopType::Mul;
                         xx.m_right = right_inverse;
                     }

--- a/src/libasr/pass/flip_sign.cpp
+++ b/src/libasr/pass/flip_sign.cpp
@@ -118,13 +118,12 @@ public:
     }
 
     void visit_Assignment(const ASR::Assignment_t& x) {
-        if( x.m_value->type == ASR::exprType::UnaryOp ) {
+        if( x.m_value->type == ASR::exprType::RealUnaryMinus ) {
             is_unary_op_present = true;
             ASR::symbol_t* sym = nullptr;
-            ASR::UnaryOp_t* negation = ASR::down_cast<ASR::UnaryOp_t>(x.m_value);
-            if( negation->m_operand->type == ASR::exprType::Var &&
-                negation->m_op == ASR::unaryopType::USub ) {
-                ASR::Var_t* var = ASR::down_cast<ASR::Var_t>(negation->m_operand);
+            ASR::RealUnaryMinus_t* negation = ASR::down_cast<ASR::RealUnaryMinus_t>(x.m_value);
+            if( negation->m_arg->type == ASR::exprType::Var ) {
+                ASR::Var_t* var = ASR::down_cast<ASR::Var_t>(negation->m_arg);
                 sym = var->m_v;
             }
             if( x.m_target->type == ASR::exprType::Var ) {
@@ -135,7 +134,28 @@ public:
         }
     }
 
-    void visit_Compare(const ASR::Compare_t& x) {
+    void visit_IntegerCompare(const ASR::IntegerCompare_t& x) {
+        handle_Compare(x);
+    }
+
+    void visit_RealCompare(const ASR::RealCompare_t &x) {
+        handle_Compare(x);
+    }
+
+    void visit_ComplexCompare(const ASR::ComplexCompare_t &x) {
+        handle_Compare(x);
+    }
+
+    void visit_LogicalCompare(const ASR::LogicalCompare_t &x) {
+        handle_Compare(x);
+    }
+
+    void visit_StringCompare(const ASR::StringCompare_t &x) {
+        handle_Compare(x);
+    }
+
+    template <typename T>
+    void handle_Compare(const T& x) {
         is_compare_present = true;
         ASR::expr_t* potential_one = nullptr;
         ASR::expr_t* potential_func_call = nullptr;

--- a/src/libasr/pass/fma.cpp
+++ b/src/libasr/pass/fma.cpp
@@ -53,23 +53,25 @@ public:
     }
 
     bool is_BinOpMul(ASR::expr_t* expr) {
-        if( expr->type == ASR::exprType::BinOp ) {
-            ASR::BinOp_t* expr_binop = ASR::down_cast<ASR::BinOp_t>(expr);
+        if (ASR::is_a<ASR::RealBinOp_t>(*expr)) {
+            ASR::RealBinOp_t* expr_binop = ASR::down_cast<ASR::RealBinOp_t>(expr);
             return expr_binop->m_op == ASR::binopType::Mul;
         }
         return false;
     }
 
-    void visit_BinOp(const ASR::BinOp_t& x_const) {
+    void visit_IntegerBinOp(const ASR::IntegerBinOp_t& /*x*/) { }
+    void visit_ComplexBinOp(const ASR::ComplexBinOp_t& /*x*/) { }
+    void visit_LogicalBinOp(const ASR::LogicalBinOp_t& /*x*/) { }
+
+    void visit_RealBinOp(const ASR::RealBinOp_t& x_const) {
         if( !from_fma ) {
             return ;
         }
 
         from_fma = true;
-        if( x_const.m_type->type != ASR::ttypeType::Real ) {
-            return ;
-        }
-        ASR::BinOp_t& x = const_cast<ASR::BinOp_t&>(x_const);
+        LFORTRAN_ASSERT(ASRUtils::is_real(*x_const.m_type))
+        ASR::RealBinOp_t& x = const_cast<ASR::RealBinOp_t&>(x_const);
 
         fma_var = nullptr;
         visit_expr(*x.m_left);
@@ -102,18 +104,16 @@ public:
         }
 
         if( is_other_expr_negative ) {
-            other_expr = ASRUtils::EXPR(ASR::make_UnaryOp_t(al, other_expr->base.loc,
-                            ASR::unaryopType::USub, other_expr, ASRUtils::expr_type(other_expr),
-                            nullptr));
+            other_expr = ASRUtils::EXPR(ASR::make_RealUnaryMinus_t(al, other_expr->base.loc, other_expr,
+                ASRUtils::expr_type(other_expr), nullptr));
         }
 
-        ASR::BinOp_t* mul_binop = ASR::down_cast<ASR::BinOp_t>(mul_expr);
+        ASR::RealBinOp_t* mul_binop = ASR::down_cast<ASR::RealBinOp_t>(mul_expr);
         ASR::expr_t *first_arg = mul_binop->m_left, *second_arg = mul_binop->m_right;
 
         if( is_mul_expr_negative ) {
-            first_arg = ASRUtils::EXPR(ASR::make_UnaryOp_t(al, first_arg->base.loc,
-                            ASR::unaryopType::USub, first_arg, ASRUtils::expr_type(first_arg),
-                            nullptr));
+            first_arg = ASRUtils::EXPR(ASR::make_RealUnaryMinus_t(al, first_arg->base.loc, first_arg,
+                ASRUtils::expr_type(first_arg), nullptr));
         }
 
         fma_var = PassUtils::get_fma(other_expr, first_arg, second_arg,
@@ -134,13 +134,30 @@ public:
         from_fma = false;
     }
 
-    void visit_UnaryOp(const ASR::UnaryOp_t& x) {
+    void visit_IntegerUnaryMinus(const ASR::IntegerUnaryMinus_t &x) {
+        visit_UnaryOp(x);
+    }
+    void visit_RealUnaryMinus(const ASR::RealUnaryMinus_t &x) {
+        visit_UnaryOp(x);
+    }
+    void visit_ComplexUnaryMinus(const ASR::ComplexUnaryMinus_t &x) {
+        visit_UnaryOp(x);
+    }
+    void visit_IntegerBitNot(const ASR::IntegerBitNot_t &x) {
+        visit_UnaryOp(x);
+    }
+    void visit_LogicalNot(const ASR::LogicalNot_t &x) {
+        visit_UnaryOp(x);
+    }
+
+    template<typename T>
+    void visit_UnaryOp(const T& x) {
         from_fma = true;
-        ASR::UnaryOp_t& xx = const_cast<ASR::UnaryOp_t&>(x);
+        T& xx = const_cast<T&>(x);
         fma_var = nullptr;
-        visit_expr(*x.m_operand);
+        visit_expr(*x.m_arg);
         if( fma_var ) {
-            xx.m_operand = fma_var;
+            xx.m_arg = fma_var;
         }
         fma_var = nullptr;
         from_fma = false;

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -62,7 +62,24 @@ public:
         contains_array = false;
     }
 
-    void visit_BinOp(const ASR::BinOp_t& x) {
+    void visit_IntegerBinOp(const ASR::IntegerBinOp_t& x) {
+        handle_BinOp(x);
+    }
+
+    void visit_RealBinOp(const ASR::RealBinOp_t& x) {
+        handle_BinOp(x);
+    }
+
+    void visit_ComplexBinOp(const ASR::ComplexBinOp_t& x) {
+        handle_BinOp(x);
+    }
+
+    void visit_LogicalBinOp(const ASR::LogicalBinOp_t& x) {
+        handle_BinOp(x);
+    }
+
+    template <typename T>
+    void handle_BinOp(const T& x) {
         if( contains_array ) {
             return ;
         }
@@ -90,9 +107,9 @@ public:
         const_n = offset = num_grps = grp_start = nullptr;
         if( arr_idx == nullptr ) {
             const_n = LFortran::ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, arr_var->base.base.loc, idoloop->n_values, _type));
-            offset = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, arr_var->base.base.loc, idoloop->m_var, ASR::binopType::Sub, idoloop->m_start, _type, nullptr, nullptr));
-            num_grps = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, arr_var->base.base.loc, offset, ASR::binopType::Mul, const_n, _type, nullptr, nullptr));
-            grp_start = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, arr_var->base.base.loc, num_grps, ASR::binopType::Add, const_1, _type, nullptr, nullptr));
+            offset = LFortran::ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, arr_var->base.base.loc, idoloop->m_var, ASR::binopType::Sub, idoloop->m_start, _type, nullptr));
+            num_grps = LFortran::ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, arr_var->base.base.loc, offset, ASR::binopType::Mul, const_n, _type, nullptr));
+            grp_start = LFortran::ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, arr_var->base.base.loc, num_grps, ASR::binopType::Add, const_1, _type, nullptr));
         }
         for( size_t i = 0; i < idoloop->n_values; i++ ) {
             Vec<ASR::array_index_t> args;
@@ -101,9 +118,8 @@ public:
             ai.m_left = nullptr;
             if( arr_idx == nullptr ) {
                 ASR::expr_t* const_i = LFortran::ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, arr_var->base.base.loc, i, _type));
-                ASR::expr_t* idx = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, arr_var->base.base.loc,
-                                                            grp_start, ASR::binopType::Add, const_i,
-                                                            _type, nullptr, nullptr));
+                ASR::expr_t* idx = LFortran::ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, arr_var->base.base.loc,
+                                                            grp_start, ASR::binopType::Add, const_i, _type, nullptr));
                 ai.m_right = idx;
             } else {
                 ai.m_right = arr_idx;
@@ -120,7 +136,7 @@ public:
             ASR::stmt_t* doloop_stmt = LFortran::ASRUtils::STMT(ASR::make_Assignment_t(al, arr_var->base.base.loc, array_ref, idoloop->m_values[i], nullptr));
             doloop_body.push_back(al, doloop_stmt);
             if( arr_idx != nullptr ) {
-                ASR::expr_t* increment = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, arr_var->base.base.loc, arr_idx, ASR::binopType::Add, const_1, LFortran::ASRUtils::expr_type(arr_idx), nullptr, nullptr));
+                ASR::expr_t* increment = LFortran::ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, arr_var->base.base.loc, arr_idx, ASR::binopType::Add, const_1, LFortran::ASRUtils::expr_type(arr_idx), nullptr));
                 ASR::stmt_t* assign_stmt = LFortran::ASRUtils::STMT(ASR::make_Assignment_t(al, arr_var->base.base.loc, arr_idx, increment, nullptr));
                 doloop_body.push_back(al, assign_stmt);
             }
@@ -130,6 +146,10 @@ public:
     }
 
     void visit_Assignment(const ASR::Assignment_t &x) {
+        if( ASR::is_a<ASR::Pointer_t>(*ASRUtils::expr_type(x.m_target)) &&
+            ASR::is_a<ASR::GetPointer_t>(*x.m_value) ) {
+            return ;
+        }
         if( x.m_value->type == ASR::exprType::ArrayConstant ) {
             ASR::ArrayConstant_t* arr_init = ((ASR::ArrayConstant_t*)(&(x.m_value->base)));
             if( arr_init->n_args == 1 && arr_init->m_args[0] != nullptr &&
@@ -176,7 +196,7 @@ public:
                                                                             LFortran::ASRUtils::expr_type(LFortran::ASRUtils::EXPR((ASR::asr_t*)arr_var)), nullptr));
                         ASR::stmt_t* assign_stmt = LFortran::ASRUtils::STMT(ASR::make_Assignment_t(al, arr_var->base.base.loc, array_ref, arr_init->m_args[k], nullptr));
                         pass_result.push_back(al, assign_stmt);
-                        ASR::expr_t* increment = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, arr_var->base.base.loc, idx_var, ASR::binopType::Add, const_1, LFortran::ASRUtils::expr_type(idx_var), nullptr, nullptr));
+                        ASR::expr_t* increment = LFortran::ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, arr_var->base.base.loc, idx_var, ASR::binopType::Add, const_1, LFortran::ASRUtils::expr_type(idx_var), nullptr));
                         assign_stmt = LFortran::ASRUtils::STMT(ASR::make_Assignment_t(al, arr_var->base.base.loc, idx_var, increment, nullptr));
                         pass_result.push_back(al, assign_stmt);
                     }

--- a/src/libasr/pass/inline_function_calls.cpp
+++ b/src/libasr/pass/inline_function_calls.cpp
@@ -58,6 +58,9 @@ private:
     ASR::ExprStmtDuplicator node_duplicator;
 
     SymbolTable* current_routine_scope;
+    ASRUtils::LabelGenerator* label_generator;
+    ASR::symbol_t* empty_block;
+    ASRUtils::ReplaceReturnWithGotoVisitor return_replacer;
 
 public:
 
@@ -68,7 +71,10 @@ public:
     rl_path(rl_path_), function_result_var(nullptr),
     from_inline_function_call(false), inlining_function(false), fixed_duplicated_expr_stmt(false),
     current_routine(""), inline_external_symbol_calls(inline_external_symbol_calls_),
-    node_duplicator(al_), current_routine_scope(nullptr), function_inlined(false)
+    node_duplicator(al_), current_routine_scope(nullptr),
+    label_generator(ASRUtils::LabelGenerator::get_instance()),
+    empty_block(nullptr), return_replacer(al_, 0),
+    function_inlined(false)
     {
         pass_result.reserve(al, 1);
     }
@@ -111,6 +117,23 @@ public:
         } else {
             fixed_duplicated_expr_stmt = false;
         }
+    }
+
+    void set_empty_block(SymbolTable* scope, const Location& loc) {
+        std::string empty_block_name = scope->get_unique_name("~empty_block");
+        if( empty_block_name != "~empty_block" ) {
+            empty_block = scope->get_symbol("~empty_block");
+        } else {
+            SymbolTable* empty_symtab = al.make_new<SymbolTable>(scope);
+            empty_block = ASR::down_cast<ASR::symbol_t>(ASR::make_Block_t(al, loc,
+                                empty_symtab,
+                                s2c(al, empty_block_name), nullptr, 0));
+            scope->add_symbol(empty_block_name, empty_block);
+        }
+    }
+
+    void remove_empty_block(SymbolTable* scope) {
+        scope->erase_symbol("~empty_block");
     }
 
     void visit_FunctionCall(const ASR::FunctionCall_t& x) {
@@ -240,6 +263,10 @@ public:
         // the ones other than the arguments.
         // exprs_to_be_visited temporarily stores the initilisation expression as well.
         for( auto& itr : func->m_symtab->get_scope() ) {
+            if( startswith(itr.first, "~empty_block") ) {
+                set_empty_block(current_scope, func->base.base.loc);
+                continue;
+            }
             ASR::Variable_t* func_var = ASR::down_cast<ASR::Variable_t>(itr.second);
             std::string func_var_name = itr.first;
             if( arg2value.find(func_var_name) == arg2value.end() ) {
@@ -315,6 +342,13 @@ public:
             }
 
             if( success ) {
+                set_empty_block(current_scope, func->base.base.loc);
+                uint64_t block_call_label = label_generator->get_unique_label();
+                ASR::stmt_t* block_call = ASRUtils::STMT(ASR::make_BlockCall_t(al, x.base.base.loc,
+                                                        block_call_label, empty_block));
+                label_generator->add_node_with_unique_label((ASR::asr_t*) block_call,
+                                                            block_call_label);
+                return_replacer.set_goto_label(block_call_label);
                 // If duplication is successfull then fill the
                 // pass result with assignment statements
                 // (for local variables in the loop just below)
@@ -323,8 +357,18 @@ public:
                     pass_result.push_back(al, pass_result_local[i]);
                 }
 
+                bool is_goto_added = false;
                 for( size_t i = 0; i < func->n_body; i++ ) {
+                    return_replacer.current_stmt = &func_copy.p[i];
+                    return_replacer.has_replacement_happened = false;
+                    return_replacer.replace_stmt(func_copy[i]);
+                    is_goto_added = is_goto_added || return_replacer.has_replacement_happened;
                     pass_result.push_back(al, func_copy[i]);
+                }
+                if( is_goto_added ) {
+                    pass_result.push_back(al, block_call);
+                } else {
+                    remove_empty_block(current_scope);
                 }
             }
             inlining_function = false;
@@ -349,8 +393,25 @@ public:
         arg2value.clear();
     }
 
-    void visit_BinOp(const ASR::BinOp_t& x) {
-        ASR::BinOp_t& xx = const_cast<ASR::BinOp_t&>(x);
+    void visit_IntegerBinOp(const ASR::IntegerBinOp_t& x) {
+        handle_BinOp(x);
+    }
+
+    void visit_RealBinOp(const ASR::RealBinOp_t& x) {
+        handle_BinOp(x);
+    }
+
+    void visit_ComplexBinOp(const ASR::ComplexBinOp_t& x) {
+        handle_BinOp(x);
+    }
+
+    void visit_LogicalBinOp(const ASR::LogicalBinOp_t& x) {
+        handle_BinOp(x);
+    }
+
+    template <typename T>
+    void handle_BinOp(const T& x) {
+        T& xx = const_cast<T&>(x);
         from_inline_function_call = true;
         function_result_var = nullptr;
         visit_expr(*x.m_left);

--- a/src/libasr/pass/loop_vectorise.cpp
+++ b/src/libasr/pass/loop_vectorise.cpp
@@ -1,0 +1,199 @@
+#include <libasr/asr.h>
+#include <libasr/containers.h>
+#include <libasr/exception.h>
+#include <libasr/asr_utils.h>
+#include <libasr/asr_verify.h>
+#include <libasr/pass/loop_vectorise.h>
+#include <libasr/pass/pass_utils.h>
+
+#include <vector>
+#include <utility>
+#include <cmath>
+
+
+namespace LFortran {
+
+using ASR::down_cast;
+using ASR::is_a;
+
+/*
+
+This ASR pass converts loops over arrays with a call to internal
+optimization routine for loop vectorisation. This allows backend
+specific code generation for vector operations resulting in optimized
+code.
+
+Converts:
+
+    i: i32
+    for i in range(9216):
+        a[i] = b[i]
+
+to:
+
+    for i in range(0, 9216, 8):
+        vector_copy(8, a[i*8:(i+1)*8], b[i*8:(i+1)*8])
+
+*/
+class LoopVectoriseVisitor : public PassUtils::SkipOptimizationSubroutineVisitor<LoopVectoriseVisitor>
+{
+private:
+    ASR::TranslationUnit_t &unit;
+
+    std::string rl_path;
+
+    // To make sure that FMA is applied only for
+    // the nodes implemented in this class
+    bool from_loop_vectorise;
+
+    const int64_t avx512 = 512;
+
+public:
+    LoopVectoriseVisitor(Allocator &al_, ASR::TranslationUnit_t &unit_,
+                         const std::string& rl_path_) : SkipOptimizationSubroutineVisitor(al_),
+    unit(unit_), rl_path(rl_path_), from_loop_vectorise(false)
+    {
+        pass_result.reserve(al, 1);
+    }
+
+    bool is_loop(const ASR::stmt_t& x) {
+        return (ASR::is_a<ASR::DoLoop_t>(x) ||
+                ASR::is_a<ASR::WhileLoop_t>(x));
+    }
+
+    bool is_vector_copy(ASR::stmt_t* x, Vec<ASR::symbol_t*>& arrays) {
+        if( !ASR::is_a<ASR::Assignment_t>(*x) ) {
+            return false;
+        }
+        ASR::Assignment_t* x_assignment = ASR::down_cast<ASR::Assignment_t>(x);
+        ASR::expr_t* target = x_assignment->m_target;
+        ASR::expr_t* value = x_assignment->m_value;
+        if( !ASR::is_a<ASR::ArrayRef_t>(*target) ||
+            !ASR::is_a<ASR::ArrayRef_t>(*value) ) {
+            return false;
+        }
+        ASR::ArrayRef_t* target_array_ref = ASR::down_cast<ASR::ArrayRef_t>(target);
+        ASR::ArrayRef_t* value_array_ref = ASR::down_cast<ASR::ArrayRef_t>(value);
+        if( target_array_ref->m_args->m_left ||
+            target_array_ref->m_args->m_step ||
+            value_array_ref->m_args->m_left ||
+            value_array_ref->m_args->m_step ) {
+            return false;
+        }
+        arrays.push_back(al, target_array_ref->m_v);
+        arrays.push_back(al, value_array_ref->m_v);
+        return true;
+    }
+
+    int64_t select_vector_instruction_size() {
+        return avx512;
+    }
+
+    int64_t get_vector_length(ASR::ttype_t* type) {
+        int kind = ASRUtils::extract_kind_from_ttype_t(type);
+        int64_t instruction_length = select_vector_instruction_size();
+        // TODO: Add check for divisibility and raise error if needed.
+        return instruction_length/(kind * 8);
+    }
+
+    void get_vector_intrinsic(ASR::stmt_t* loop_stmt, ASR::expr_t* index,
+                              ASR::expr_t*& vector_length,
+                              Vec<ASR::stmt_t*>& vectorised_loop_body) {
+        LFORTRAN_ASSERT(vectorised_loop_body.reserve_called);
+        Vec<ASR::symbol_t*> arrays;
+        arrays.reserve(al, 2);
+        if( is_vector_copy(loop_stmt, arrays) ) {
+            ASR::symbol_t *target_sym = arrays[0], *value_sym = arrays[1];
+            ASR::ttype_t* target_type = ASRUtils::symbol_type(target_sym);
+            int64_t vector_length_int = get_vector_length(target_type);
+            vector_length = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loop_stmt->base.loc,
+                                vector_length_int, ASRUtils::expr_type(index)));
+            ASR::expr_t* start = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, loop_stmt->base.loc, index, ASR::binopType::Mul,
+                                        vector_length, ASRUtils::expr_type(index), nullptr));
+            ASR::expr_t* one = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loop_stmt->base.loc,
+                                    1, ASRUtils::expr_type(index)));
+            ASR::expr_t* next_index = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, loop_stmt->base.loc, index, ASR::binopType::Add,
+                                            one, ASRUtils::expr_type(index), nullptr));
+            ASR::expr_t* end = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, loop_stmt->base.loc, next_index, ASR::binopType::Mul,
+                                        vector_length, ASRUtils::expr_type(index), nullptr));
+            vectorised_loop_body.push_back(al, PassUtils::get_vector_copy(target_sym, value_sym, start,
+                end, one, vector_length,
+                al, unit,
+                current_scope, loop_stmt->base.loc));
+            return ;
+        }
+    }
+
+    void vectorise_loop(const ASR::DoLoop_t& x) {
+        // Do Vectorisation of Loop inside this function
+        ASR::expr_t* loop_start = x.m_head.m_start;
+        ASR::expr_t* loop_end = x.m_head.m_end;
+        ASR::expr_t* loop_inc = x.m_head.m_increment;
+        ASR::expr_t* loop_start_value = ASRUtils::expr_value(loop_start);
+        ASR::expr_t* loop_end_value = ASRUtils::expr_value(loop_end);
+        ASR::expr_t* loop_inc_value = ASRUtils::expr_value(loop_inc);
+        if( !ASRUtils::is_value_constant(loop_start_value) ||
+            !ASRUtils::is_value_constant(loop_end_value) ||
+            !ASRUtils::is_value_constant(loop_inc_value) ) {
+            // Skip vectorisation of variable sized loops
+            return ;
+        }
+        ASR::stmt_t* loop_stmt = x.m_body[0];
+        int64_t loop_start_int = -1, loop_end_int = -1, loop_inc_int = -1;
+        ASRUtils::extract_value(loop_start_value, loop_start_int);
+        ASRUtils::extract_value(loop_end_value, loop_end_int);
+        ASRUtils::extract_value(loop_inc_value, loop_inc_int);
+        int64_t loop_size = (loop_end_int - loop_start_int) / loop_inc_int + 1;
+        ASR::expr_t* vector_length = nullptr;
+        Vec<ASR::stmt_t*> vectorised_loop_body;
+        vectorised_loop_body.reserve(al, x.n_body);
+        get_vector_intrinsic(loop_stmt, x.m_head.m_v,
+                             vector_length, vectorised_loop_body);
+        if( !vector_length ) {
+            return ;
+        }
+        ASR::do_loop_head_t vectorised_loop_head;
+        vectorised_loop_head.m_start = loop_start;
+        int64_t vector_length_int;
+        ASRUtils::extract_value(vector_length, vector_length_int);
+        // TODO: Add tests for loop sizes not divisible by vector_length.
+        vectorised_loop_head.m_end = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.m_head.m_v->base.loc,
+                                        loop_size/vector_length_int - 1, ASRUtils::expr_type(x.m_head.m_v)));
+        // TODO: Update this for increments other 1.
+        ASR::expr_t* one = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loop_stmt->base.loc,
+                                    1, ASRUtils::expr_type(x.m_head.m_v)));
+        vectorised_loop_head.m_increment = one;
+        vectorised_loop_head.m_v = x.m_head.m_v;
+        vectorised_loop_head.loc = x.m_head.loc;
+
+        ASR::stmt_t* vectorised_loop = ASRUtils::STMT(ASR::make_DoLoop_t(al, x.base.base.loc,
+                                            vectorised_loop_head, vectorised_loop_body.p,
+                                            vectorised_loop_body.size()));
+        pass_result.push_back(al, vectorised_loop);
+    }
+
+    void visit_DoLoop(const ASR::DoLoop_t& x) {
+        from_loop_vectorise = true;
+        if( x.n_body == 1 ) {
+            // Vectorise
+            if( is_loop(*x.m_body[0]) ) {
+                from_loop_vectorise = false;
+                visit_stmt(*x.m_body[0]);
+                return ;
+            }
+            vectorise_loop(x);
+        }
+        from_loop_vectorise = false;
+    }
+
+};
+
+void pass_loop_vectorise(Allocator &al, ASR::TranslationUnit_t &unit,
+                         const std::string& rl_path) {
+    LoopVectoriseVisitor v(al, unit, rl_path);
+    v.visit_TranslationUnit(unit);
+    LFORTRAN_ASSERT(asr_verify(unit));
+}
+
+
+} // namespace LFortran

--- a/src/libasr/pass/loop_vectorise.cpp
+++ b/src/libasr/pass/loop_vectorise.cpp
@@ -154,7 +154,7 @@ public:
         }
         ASR::do_loop_head_t vectorised_loop_head;
         vectorised_loop_head.m_start = loop_start;
-        int64_t vector_length_int;
+        int64_t vector_length_int = -1;
         ASRUtils::extract_value(vector_length, vector_length_int);
         // TODO: Add tests for loop sizes not divisible by vector_length.
         vectorised_loop_head.m_end = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.m_head.m_v->base.loc,

--- a/src/libasr/pass/loop_vectorise.h
+++ b/src/libasr/pass/loop_vectorise.h
@@ -1,0 +1,13 @@
+#ifndef LIBASR_PASS_LOOP_VECTORISE_H
+#define LIBASR_PASS_LOOP_VECTORISE_H
+
+#include <libasr/asr.h>
+
+namespace LFortran {
+
+    void pass_loop_vectorise(Allocator &al, ASR::TranslationUnit_t &unit,
+                             const std::string& rl_path);
+
+} // namespace LFortran
+
+#endif // LIBASR_PASS_LOOP_VECTORISE_H

--- a/src/libasr/pass/param_to_const.cpp
+++ b/src/libasr/pass/param_to_const.cpp
@@ -49,18 +49,56 @@ public:
         }
     }
 
-    void visit_UnaryOp(const ASR::UnaryOp_t& x) {
-        ASR::UnaryOp_t& x_unconst = const_cast<ASR::UnaryOp_t&>(x);
+    void visit_IntegerUnaryMinus(const ASR::IntegerUnaryMinus_t &x) {
+        visit_UnaryOp(x);
+    }
+    void visit_RealUnaryMinus(const ASR::RealUnaryMinus_t &x) {
+        visit_UnaryOp(x);
+    }
+    void visit_ComplexUnaryMinus(const ASR::ComplexUnaryMinus_t &x) {
+        visit_UnaryOp(x);
+    }
+    void visit_IntegerBitNot(const ASR::IntegerBitNot_t &x) {
+        visit_UnaryOp(x);
+    }
+    void visit_LogicalNot(const ASR::LogicalNot_t &x) {
+        visit_UnaryOp(x);
+    }
+
+    template<typename T>
+    void visit_UnaryOp(const T& x) {
+        T& x_unconst = const_cast<T&>(x);
         asr = nullptr;
-        this->visit_expr(*x.m_operand);
+        this->visit_expr(*x.m_arg);
         if( asr != nullptr ) {
-            x_unconst.m_operand = asr;
+            x_unconst.m_arg = asr;
         }
         asr = const_cast<ASR::expr_t*>(&(x.base));
     }
 
-    void visit_Compare(const ASR::Compare_t& x) {
-        ASR::Compare_t& x_unconst = const_cast<ASR::Compare_t&>(x);
+    void visit_IntegerCompare(const ASR::IntegerCompare_t& x) {
+        handle_Compare(x);
+    }
+
+    void visit_RealCompare(const ASR::RealCompare_t &x) {
+        handle_Compare(x);
+    }
+
+    void visit_ComplexCompare(const ASR::ComplexCompare_t &x) {
+        handle_Compare(x);
+    }
+
+    void visit_LogicalCompare(const ASR::LogicalCompare_t &x) {
+        handle_Compare(x);
+    }
+
+    void visit_StringCompare(const ASR::StringCompare_t &x) {
+        handle_Compare(x);
+    }
+
+    template <typename T>
+    void handle_Compare(const T& x) {
+        T& x_unconst = const_cast<T&>(x);
         asr = nullptr;
         this->visit_expr(*x.m_left);
         if( asr != nullptr ) {
@@ -74,8 +112,25 @@ public:
         asr = const_cast<ASR::expr_t*>(&(x.base));
     }
 
-    void visit_BinOp(const ASR::BinOp_t& x) {
-        ASR::BinOp_t& x_unconst = const_cast<ASR::BinOp_t&>(x);
+    void visit_IntegerBinOp(const ASR::IntegerBinOp_t& x) {
+        handle_BinOp(x);
+    }
+
+    void visit_RealBinOp(const ASR::RealBinOp_t& x) {
+        handle_BinOp(x);
+    }
+
+    void visit_ComplexBinOp(const ASR::ComplexBinOp_t& x) {
+        handle_BinOp(x);
+    }
+
+    void visit_LogicalBinOp(const ASR::LogicalBinOp_t& x) {
+        handle_BinOp(x);
+    }
+
+    template <typename T>
+    void handle_BinOp(const T& x) {
+        T& x_unconst = const_cast<T&>(x);
         asr = nullptr;
         this->visit_expr(*x.m_left);
         if( asr != nullptr ) {

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -39,8 +39,6 @@
 #include <map>
 #include <vector>
 
-#include <iostream>
-
 namespace LCompilers {
 
     enum ASRPass {

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -1,0 +1,264 @@
+#ifndef LCOMPILERS_PASS_MANAGER_H
+#define LCOMPILERS_PASS_MANAGER_H
+
+#include <libasr/asr.h>
+#include <libasr/string_utils.h>
+#include <libasr/alloc.h>
+
+// TODO: Remove lpython/lfortran includes, make it compiler agnostic
+#if __has_include(<lfortran/utils.h>)
+    #include <lfortran/utils.h>
+#endif
+
+#if __has_include(<lpython/utils.h>)
+    #include <lpython/utils.h>
+#endif
+
+#include <libasr/pass/do_loops.h>
+#include <libasr/pass/for_all.h>
+#include <libasr/pass/implied_do_loops.h>
+#include <libasr/pass/array_op.h>
+#include <libasr/pass/select_case.h>
+#include <libasr/pass/global_stmts.h>
+#include <libasr/pass/param_to_const.h>
+#include <libasr/pass/print_arr.h>
+#include <libasr/pass/arr_slice.h>
+#include <libasr/pass/flip_sign.h>
+#include <libasr/pass/div_to_mul.h>
+#include <libasr/pass/fma.h>
+#include <libasr/pass/loop_unroll.h>
+#include <libasr/pass/sign_from_value.h>
+#include <libasr/pass/class_constructor.h>
+#include <libasr/pass/unused_functions.h>
+#include <libasr/pass/inline_function_calls.h>
+#include <libasr/pass/dead_code_removal.h>
+#include <libasr/pass/for_all.h>
+#include <libasr/pass/select_case.h>
+#include <libasr/pass/loop_vectorise.h>
+
+#include <map>
+#include <vector>
+
+#include <iostream>
+
+namespace LCompilers {
+
+    enum ASRPass {
+        do_loops, global_stmts, implied_do_loops, array_op,
+        arr_slice, print_arr, class_constructor, unused_functions,
+        flip_sign, div_to_mul, fma, sign_from_value,
+        inline_function_calls, loop_unroll, dead_code_removal,
+        forall, select_case, loop_vectorise
+    };
+
+    class PassManager {
+        private:
+
+        std::vector<ASRPass> _passes;
+        std::vector<ASRPass> _with_optimization_passes;
+        std::vector<ASRPass> _user_defined_passes;
+        std::map<std::string, ASRPass> _passes_db = {
+            {"do_loops", ASRPass::do_loops},
+            {"global_stmts", ASRPass::global_stmts},
+            {"implied_do_loops", ASRPass::implied_do_loops},
+            {"array_op", ASRPass::array_op},
+            {"arr_slice", ASRPass::arr_slice},
+            {"print_arr", ASRPass::print_arr},
+            {"class_constructor", ASRPass::class_constructor},
+            {"unused_functions", ASRPass::unused_functions},
+            {"flip_sign", ASRPass::flip_sign},
+            {"div_to_mul", ASRPass::div_to_mul},
+            {"fma", ASRPass::fma},
+            {"sign_from_value", ASRPass::sign_from_value},
+            {"inline_function_calls", ASRPass::inline_function_calls},
+            {"loop_unroll", ASRPass::loop_unroll},
+            {"dead_code_removal", ASRPass::dead_code_removal},
+            {"forall", ASRPass::forall},
+            {"select_case", ASRPass::select_case},
+            {"loop_vectorise", ASRPass::loop_vectorise}
+        };
+
+        bool is_fast;
+        bool apply_default_passes;
+
+        void _apply_passes(Allocator& al, LFortran::ASR::TranslationUnit_t* asr,
+                           std::vector<ASRPass>& passes, std::string& run_fun,
+                           bool always_run) {
+            for (size_t i = 0; i < passes.size(); i++) {
+                switch (passes[i]) {
+                    case (ASRPass::do_loops) : {
+                        LFortran::pass_replace_do_loops(al, *asr);
+                        break;
+                    }
+                    case (ASRPass::global_stmts) : {
+                        LFortran::pass_wrap_global_stmts_into_function(al, *asr, run_fun);
+                        break;
+                    }
+                    case (ASRPass::implied_do_loops) : {
+                        LFortran::pass_replace_implied_do_loops(al, *asr, LFortran::get_runtime_library_dir());
+                        break;
+                    }
+                    case (ASRPass::array_op) : {
+                        LFortran::pass_replace_array_op(al, *asr, LFortran::get_runtime_library_dir());
+                        break;
+                    }
+                    case (ASRPass::flip_sign) : {
+                        LFortran::pass_replace_flip_sign(al, *asr, LFortran::get_runtime_library_dir());
+                        break;
+                    }
+                    case (ASRPass::fma) : {
+                        LFortran::pass_replace_fma(al, *asr, LFortran::get_runtime_library_dir());
+                        break;
+                    }
+                    case (ASRPass::loop_unroll) : {
+                        LFortran::pass_loop_unroll(al, *asr, LFortran::get_runtime_library_dir());
+                        break;
+                    }
+                    case (ASRPass::inline_function_calls) : {
+                        LFortran::pass_inline_function_calls(al, *asr, LFortran::get_runtime_library_dir());
+                        break;
+                    }
+                    case (ASRPass::dead_code_removal) : {
+                        LFortran::pass_dead_code_removal(al, *asr, LFortran::get_runtime_library_dir());
+                        break;
+                    }
+                    case (ASRPass::sign_from_value) : {
+                        LFortran::pass_replace_sign_from_value(al, *asr, LFortran::get_runtime_library_dir());
+                        break;
+                    }
+                    case (ASRPass::div_to_mul) : {
+                        LFortran::pass_replace_div_to_mul(al, *asr, LFortran::get_runtime_library_dir());
+                        break;
+                    }
+                    case (ASRPass::class_constructor) : {
+                        LFortran::pass_replace_class_constructor(al, *asr);
+                        break;
+                    }
+                    case (ASRPass::arr_slice) : {
+                        LFortran::pass_replace_arr_slice(al, *asr, LFortran::get_runtime_library_dir());
+                        break;
+                    }
+                    case (ASRPass::print_arr) : {
+                        LFortran::pass_replace_print_arr(al, *asr, LFortran::get_runtime_library_dir());
+                        break;
+                    }
+                    case (ASRPass::unused_functions) : {
+                        LFortran::pass_unused_functions(al, *asr, always_run);
+                        break;
+                    }
+                    case (ASRPass::forall) : {
+                        LFortran::pass_replace_forall(al, *asr);
+                        break ;
+                    }
+                    case (ASRPass::select_case) : {
+                        LFortran::pass_replace_select_case(al, *asr);
+                        break;
+                    }
+                    case (ASRPass::loop_vectorise) : {
+                        LFortran::pass_loop_vectorise(al, *asr, LFortran::get_runtime_library_dir());
+                        break;
+                    }
+                }
+            }
+        }
+
+        public:
+
+        PassManager(): is_fast{false}, apply_default_passes{false} {
+            _passes = {
+                ASRPass::global_stmts,
+                ASRPass::class_constructor,
+                ASRPass::implied_do_loops,
+                ASRPass::arr_slice,
+                ASRPass::array_op,
+                ASRPass::print_arr,
+                ASRPass::do_loops,
+                ASRPass::forall,
+                ASRPass::select_case,
+                ASRPass::unused_functions
+            };
+
+            _with_optimization_passes = {
+                ASRPass::global_stmts,
+                ASRPass::class_constructor,
+                ASRPass::implied_do_loops,
+                ASRPass::arr_slice,
+                ASRPass::array_op,
+                ASRPass::print_arr,
+                ASRPass::loop_vectorise,
+                ASRPass::loop_unroll,
+                ASRPass::do_loops,
+                ASRPass::forall,
+                ASRPass::dead_code_removal,
+                ASRPass::select_case,
+                ASRPass::unused_functions,
+                ASRPass::flip_sign,
+                ASRPass::sign_from_value,
+                ASRPass::div_to_mul,
+                ASRPass::fma,
+                ASRPass::inline_function_calls
+            };
+
+            _user_defined_passes.clear();
+        }
+
+        void parse_pass_arg(std::string& arg_pass) {
+            _user_defined_passes.clear();
+            if (arg_pass == "") {
+                return ;
+            }
+
+            std::string current_pass = "";
+            for( size_t i = 0; i < arg_pass.size(); i++ ) {
+                char ch = arg_pass[i];
+                if( ch != ' ' && ch != ',' ) {
+                    current_pass.push_back(ch);
+                }
+                if( ch == ',' || i == arg_pass.size() - 1 ) {
+                    current_pass = LFortran::to_lower(current_pass);
+                    if( _passes_db.find(current_pass) == _passes_db.end() ) {
+                        std::cerr << current_pass << " isn't supported yet.";
+                        std::cerr << " Only the following passes are supported:- "<<std::endl;
+                        for( auto it: _passes_db ) {
+                            std::cerr << it.first << std::endl;
+                        }
+                        exit(1);
+                    }
+                    _user_defined_passes.push_back(_passes_db[current_pass]);
+                    current_pass.clear();
+                }
+            }
+        }
+
+        void apply_passes(Allocator& al, LFortran::ASR::TranslationUnit_t* asr,
+                          std::string run_fun, bool always_run=false) {
+            if( !_user_defined_passes.empty() ) {
+                _apply_passes(al, asr, _user_defined_passes, run_fun, always_run);
+            } else if( apply_default_passes ) {
+                if( is_fast ) {
+                    _apply_passes(al, asr, _with_optimization_passes, run_fun, always_run);
+                } else {
+                    _apply_passes(al, asr, _passes, run_fun, always_run);
+                }
+            }
+        }
+
+        void use_optimization_passes() {
+            is_fast = true;
+        }
+
+        void do_not_use_optimization_passes() {
+            is_fast = false;
+        }
+
+        void use_default_passes() {
+            apply_default_passes = true;
+        }
+
+        void do_not_use_default_passes() {
+            apply_default_passes = false;
+        }
+    };
+
+}
+#endif

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -314,6 +314,39 @@ namespace LFortran {
             return v;
         }
 
+        ASR::expr_t* create_compare_helper(Allocator &al, const Location &loc, ASR::expr_t* left, ASR::expr_t* right,
+                                                ASR::cmpopType op) {
+            ASR::ttype_t* type = ASRUtils::expr_type(left);
+            // TODO: compute `value`:
+            if (ASRUtils::is_integer(*type)) {
+                return ASRUtils::EXPR(ASR::make_IntegerCompare_t(al, loc, left, op, right, type, nullptr));
+            } else if (ASRUtils::is_real(*type)) {
+                return ASRUtils::EXPR(ASR::make_RealCompare_t(al, loc, left, op, right, type, nullptr));
+            } else if (ASRUtils::is_complex(*type)) {
+                return ASRUtils::EXPR(ASR::make_ComplexCompare_t(al, loc, left, op, right, type, nullptr));
+            } else if (ASRUtils::is_logical(*type)) {
+                return ASRUtils::EXPR(ASR::make_LogicalCompare_t(al, loc, left, op, right, type, nullptr));
+            } else if (ASRUtils::is_character(*type)) {
+                return ASRUtils::EXPR(ASR::make_StringCompare_t(al, loc, left, op, right, type, nullptr));
+            } else {
+                throw LFortranException("Type not supported");
+            }
+        }
+
+        ASR::expr_t* create_binop_helper(Allocator &al, const Location &loc, ASR::expr_t* left, ASR::expr_t* right,
+                                                ASR::binopType op) {
+            ASR::ttype_t* type = ASRUtils::expr_type(left);
+            // TODO: compute `value`:
+            if (ASRUtils::is_integer(*type)) {
+                return ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, loc, left, op, right, type, nullptr));
+            } else if (ASRUtils::is_real(*type)) {
+                return ASRUtils::EXPR(ASR::make_RealBinOp_t(al, loc, left, op, right, type, nullptr));
+            } else if (ASRUtils::is_complex(*type)) {
+                return ASRUtils::EXPR(ASR::make_ComplexBinOp_t(al, loc, left, op, right, type, nullptr));
+            } else {
+                throw LFortranException("Type not supported");
+            }
+        }
 
         ASR::expr_t* get_bound(ASR::expr_t* arr_expr, int dim, std::string bound,
                                 Allocator& al) {
@@ -443,6 +476,97 @@ namespace LFortran {
                         loc, v, args, current_scope, al, err));
         }
 
+        ASR::symbol_t* insert_fallback_vector_copy(Allocator& al, ASR::TranslationUnit_t& unit,
+            SymbolTable*& global_scope, std::vector<ASR::ttype_t*>& types,
+            std::string prefix) {
+            const int num_args = 6;
+            std::string vector_copy_name = prefix;
+            for( ASR::ttype_t*& type: types ) {
+                vector_copy_name += ASRUtils::type_to_str_python(type, false);
+            }
+            vector_copy_name += "@IntrinsicOptimization";
+            if( global_scope->resolve_symbol(vector_copy_name) ) {
+                return global_scope->resolve_symbol(vector_copy_name);
+            }
+            Vec<ASR::expr_t*> arg_exprs;
+            arg_exprs.reserve(al, num_args);
+            SymbolTable* vector_copy_symtab = al.make_new<SymbolTable>(global_scope);
+            for( int i = 0; i < num_args; i++ ) {
+                std::string arg_name = "arg" + std::to_string(i);
+                ASR::symbol_t* arg = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(al, unit.base.base.loc, vector_copy_symtab,
+                                        s2c(al, arg_name), ASR::intentType::In, nullptr, nullptr, ASR::storage_typeType::Default,
+                                        types[std::min(i, (int) types.size() - 1)], ASR::abiType::Source, ASR::accessType::Public,
+                                        ASR::presenceType::Required, false));
+                ASR::expr_t* arg_expr = ASRUtils::EXPR(ASR::make_Var_t(al, arg->base.loc, arg));
+                arg_exprs.push_back(al, arg_expr);
+                vector_copy_symtab->add_symbol(arg_name, arg);
+            }
+            Vec<ASR::stmt_t*> body;
+            body.reserve(al, 1);
+            ASR::do_loop_head_t do_loop_head;
+            do_loop_head.m_start = arg_exprs[2];
+            do_loop_head.m_end = arg_exprs[3];
+            do_loop_head.m_increment = arg_exprs[4];
+            do_loop_head.loc = arg_exprs[2]->base.loc;
+            Vec<ASR::expr_t*> idx_vars;
+            create_idx_vars(idx_vars, 1, arg_exprs[2]->base.loc,
+                            al, vector_copy_symtab);
+            do_loop_head.m_v = idx_vars[0];
+            Vec<ASR::stmt_t*> loop_body;
+            loop_body.reserve(al, 1);
+            ASR::expr_t* target = create_array_ref(arg_exprs[0], idx_vars, al);
+            ASR::expr_t* value = create_array_ref(arg_exprs[1], idx_vars, al);
+            ASR::stmt_t* copy_stmt = ASRUtils::STMT(ASR::make_Assignment_t(al, target->base.loc,
+                                        target, value, nullptr));
+            loop_body.push_back(al, copy_stmt);
+            ASR::stmt_t* fallback_loop = ASRUtils::STMT(ASR::make_DoLoop_t(al, do_loop_head.loc,
+                                            do_loop_head, loop_body.p, loop_body.size()));
+            Vec<ASR::stmt_t*> fallback_while_loop = replace_doloop(al, *ASR::down_cast<ASR::DoLoop_t>(fallback_loop),
+                                                                  (int) ASR::cmpopType::Lt);
+            for( size_t i = 0; i < fallback_while_loop.size(); i++ ) {
+                body.push_back(al, fallback_while_loop[i]);
+            }
+            ASR::asr_t* vector_copy_asr = ASR::make_Subroutine_t(al, unit.base.base.loc, vector_copy_symtab,
+                                            s2c(al, vector_copy_name), arg_exprs.p, arg_exprs.size(), body.p,
+                                            body.size(), ASR::abiType::Source, ASR::accessType::Public, ASR::deftypeType::Implementation,
+                                            nullptr, false, false);
+            global_scope->add_symbol(vector_copy_name, ASR::down_cast<ASR::symbol_t>(vector_copy_asr));
+            return ASR::down_cast<ASR::symbol_t>(vector_copy_asr);
+        }
+
+        ASR::stmt_t* get_vector_copy(ASR::symbol_t* array0, ASR::symbol_t* array1, ASR::expr_t* start,
+            ASR::expr_t* end, ASR::expr_t* step, ASR::expr_t* vector_length,
+            Allocator& al, ASR::TranslationUnit_t& unit,
+            SymbolTable*& global_scope, Location& loc) {
+            ASR::ttype_t* array0_type = ASRUtils::symbol_type(array0);
+            ASR::ttype_t* array1_type = ASRUtils::symbol_type(array1);
+            ASR::ttype_t* index_type = ASRUtils::expr_type(start);
+            std::vector<ASR::ttype_t*> types = {array0_type, array1_type, index_type};
+            ASR::symbol_t *v = insert_fallback_vector_copy(al, unit, global_scope,
+                                                           types,
+                                                           "vector_copy_");
+            Vec<ASR::call_arg_t> args;
+            args.reserve(al, 6);
+            ASR::call_arg_t arg0_, arg1_, arg2_, arg3_, arg4_, arg5_;
+            ASR::expr_t* array0_expr = ASRUtils::EXPR(ASR::make_Var_t(al, array0->base.loc, array0));
+            arg0_.loc = array0->base.loc, arg0_.m_value = array0_expr;
+            args.push_back(al, arg0_);
+            ASR::expr_t* array1_expr = ASRUtils::EXPR(ASR::make_Var_t(al, array1->base.loc, array1));
+            arg1_.loc = array1->base.loc, arg1_.m_value = array1_expr;
+            args.push_back(al, arg1_);
+            arg2_.loc = start->base.loc, arg2_.m_value = start;
+            args.push_back(al, arg2_);
+            arg3_.loc = end->base.loc, arg3_.m_value = end;
+            args.push_back(al, arg3_);
+            arg4_.loc = step->base.loc, arg4_.m_value = step;
+            args.push_back(al, arg4_);
+            arg5_.loc = vector_length->base.loc, arg5_.m_value = vector_length;
+            args.push_back(al, arg5_);
+            return ASRUtils::STMT(ASR::make_SubroutineCall_t(al, loc, v,
+                                                             nullptr, args.p, args.size(),
+                                                             nullptr));
+        }
+
         ASR::expr_t* get_sign_from_value(ASR::expr_t* arg0, ASR::expr_t* arg1,
             Allocator& al, ASR::TranslationUnit_t& unit, std::string& rl_path,
             SymbolTable*& current_scope, Location& loc,
@@ -461,7 +585,8 @@ namespace LFortran {
                         loc, v, args, current_scope, al, err));
         }
 
-        Vec<ASR::stmt_t*> replace_doloop(Allocator &al, const ASR::DoLoop_t &loop) {
+        Vec<ASR::stmt_t*> replace_doloop(Allocator &al, const ASR::DoLoop_t &loop,
+                                         int comp) {
             Location loc = loop.base.base.loc;
             ASR::expr_t *a=loop.m_head.m_start;
             ASR::expr_t *b=loop.m_head.m_end;
@@ -480,40 +605,36 @@ namespace LFortran {
                     c = LFortran::ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 1, type));
                 }
                 LFORTRAN_ASSERT(c);
-                int increment;
-                if (c->type == ASR::exprType::IntegerConstant) {
-                    increment = ASR::down_cast<ASR::IntegerConstant_t>(c)->m_n;
-                } else if (c->type == ASR::exprType::IntegerUnaryMinus) {
-                    ASR::IntegerUnaryMinus_t *u = ASR::down_cast<ASR::IntegerUnaryMinus_t>(c);
-                    increment = - ASR::down_cast<ASR::IntegerConstant_t>(u->m_arg)->m_n;
-                } else if (c->type == ASR::exprType::UnaryOp) {
-                    // TODO: remove once we remove UnaryOp
-                    ASR::UnaryOp_t *u = ASR::down_cast<ASR::UnaryOp_t>(c);
-                    LFORTRAN_ASSERT(u->m_op == ASR::unaryopType::USub);
-                    LFORTRAN_ASSERT(u->m_operand->type == ASR::exprType::IntegerConstant);
-                    increment = - ASR::down_cast<ASR::IntegerConstant_t>(u->m_operand)->m_n;
-                } else {
-                    throw LFortranException("Do loop increment type not supported");
-                }
                 ASR::cmpopType cmp_op;
-                if (increment > 0) {
-                    cmp_op = ASR::cmpopType::LtE;
+                if( comp == -1 ) {
+                    int increment;
+                    if (c->type == ASR::exprType::IntegerConstant) {
+                        increment = ASR::down_cast<ASR::IntegerConstant_t>(c)->m_n;
+                    } else if (c->type == ASR::exprType::IntegerUnaryMinus) {
+                        ASR::IntegerUnaryMinus_t *u = ASR::down_cast<ASR::IntegerUnaryMinus_t>(c);
+                        increment = - ASR::down_cast<ASR::IntegerConstant_t>(u->m_arg)->m_n;
+                    } else {
+                        throw LFortranException("Do loop increment type not supported");
+                    }
+                    if (increment > 0) {
+                        cmp_op = ASR::cmpopType::LtE;
+                    } else {
+                        cmp_op = ASR::cmpopType::GtE;
+                    }
                 } else {
-                    cmp_op = ASR::cmpopType::GtE;
+                    cmp_op = (ASR::cmpopType) comp;
                 }
                 ASR::expr_t *target = loop.m_head.m_v;
                 ASR::ttype_t *type = LFortran::ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4, nullptr, 0));
                 stmt1 = LFortran::ASRUtils::STMT(ASR::make_Assignment_t(al, loc, target,
-                    LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, loc, a, ASR::binopType::Sub, c, type, nullptr, nullptr)),
-                    nullptr));
+                    LFortran::ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, loc, a, ASR::binopType::Sub, c, type, nullptr)), nullptr));
 
-                cond = LFortran::ASRUtils::EXPR(ASR::make_Compare_t(al, loc,
-                    LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, loc, target, ASR::binopType::Add, c, type, nullptr, nullptr)),
-                    cmp_op, b, type, nullptr, nullptr));
+                cond = LFortran::ASRUtils::EXPR(ASR::make_IntegerCompare_t(al, loc,
+                    LFortran::ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, loc, target, ASR::binopType::Add, c, type, nullptr)),
+                    cmp_op, b, type, nullptr));
 
                 inc_stmt = LFortran::ASRUtils::STMT(ASR::make_Assignment_t(al, loc, target,
-                            LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, loc, target, ASR::binopType::Add, c, type, nullptr, nullptr)),
-                        nullptr));
+                            LFortran::ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, loc, target, ASR::binopType::Add, c, type, nullptr)), nullptr));
             }
             Vec<ASR::stmt_t*> body;
             body.reserve(al, loop.n_body + (inc_stmt != nullptr));

--- a/src/libasr/pass/print_arr.cpp
+++ b/src/libasr/pass/print_arr.cpp
@@ -46,7 +46,8 @@ public:
             Vec<ASR::expr_t*> idx_vars;
             PassUtils::create_idx_vars(idx_vars, n_dims, x.base.base.loc, al, current_scope);
             ASR::stmt_t* doloop = nullptr;
-            ASR::stmt_t* empty_print_endl = LFortran::ASRUtils::STMT(ASR::make_Print_t(al, x.base.base.loc, nullptr, nullptr, 0));
+            ASR::stmt_t* empty_print_endl = LFortran::ASRUtils::STMT(ASR::make_Print_t(al, x.base.base.loc,
+                                                nullptr, nullptr, 0, nullptr, nullptr));
             for( int i = n_dims - 1; i >= 0; i-- ) {
                 ASR::do_loop_head_t head;
                 head.m_v = idx_vars[i];
@@ -62,7 +63,7 @@ public:
                     print_args.reserve(al, 1);
                     print_args.push_back(al, ref);
                     ASR::stmt_t* print_stmt = LFortran::ASRUtils::STMT(ASR::make_Print_t(al, x.base.base.loc, nullptr,
-                                                                 print_args.p, print_args.size()));
+                                                                 print_args.p, print_args.size(), nullptr, nullptr));
                     doloop_body.push_back(al, print_stmt);
                 } else {
                     doloop_body.push_back(al, doloop);

--- a/src/libasr/pass/select_case.cpp
+++ b/src/libasr/pass/select_case.cpp
@@ -51,18 +51,18 @@ to:
 inline ASR::expr_t* gen_test_expr_CaseStmt(Allocator& al, const Location& loc, ASR::CaseStmt_t* Case_Stmt, ASR::expr_t* a_test) {
     ASR::expr_t* test_expr = nullptr;
     if( Case_Stmt->n_test == 1 ) {
-        test_expr = LFortran::ASRUtils::EXPR(ASR::make_Compare_t(al, loc, a_test, ASR::cmpopType::Eq, Case_Stmt->m_test[0], LFortran::ASRUtils::expr_type(a_test), nullptr, nullptr));
+        test_expr = PassUtils::create_compare_helper(al, loc, a_test, Case_Stmt->m_test[0], ASR::cmpopType::Eq);
     } else if( Case_Stmt->n_test == 2 ) {
-        ASR::expr_t* left = LFortran::ASRUtils::EXPR(ASR::make_Compare_t(al, loc, a_test, ASR::cmpopType::Eq, Case_Stmt->m_test[0], LFortran::ASRUtils::expr_type(a_test), nullptr, nullptr));
-        ASR::expr_t* right = LFortran::ASRUtils::EXPR(ASR::make_Compare_t(al, loc, a_test, ASR::cmpopType::Eq, Case_Stmt->m_test[1], LFortran::ASRUtils::expr_type(a_test), nullptr, nullptr));
-        test_expr = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, loc, left, ASR::binopType::Add, right, LFortran::ASRUtils::expr_type(left), nullptr, nullptr));
+        ASR::expr_t* left = PassUtils::create_compare_helper(al, loc, a_test, Case_Stmt->m_test[0], ASR::cmpopType::Eq);
+        ASR::expr_t* right = PassUtils::create_compare_helper(al, loc, a_test, Case_Stmt->m_test[1], ASR::cmpopType::Eq);
+        test_expr = PassUtils::create_binop_helper(al, loc, left, right, ASR::binopType::Add);
     } else {
-        ASR::expr_t* left = LFortran::ASRUtils::EXPR(ASR::make_Compare_t(al, loc, a_test, ASR::cmpopType::Eq, Case_Stmt->m_test[0], LFortran::ASRUtils::expr_type(a_test), nullptr, nullptr));
-        ASR::expr_t* right = LFortran::ASRUtils::EXPR(ASR::make_Compare_t(al, loc, a_test, ASR::cmpopType::Eq, Case_Stmt->m_test[1], LFortran::ASRUtils::expr_type(a_test), nullptr, nullptr));
-        test_expr = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, loc, left, ASR::binopType::Add, right, LFortran::ASRUtils::expr_type(left), nullptr, nullptr));
+        ASR::expr_t* left = PassUtils::create_compare_helper(al, loc, a_test, Case_Stmt->m_test[0], ASR::cmpopType::Eq);
+        ASR::expr_t* right = PassUtils::create_compare_helper(al, loc, a_test, Case_Stmt->m_test[1], ASR::cmpopType::Eq);
+        test_expr = PassUtils::create_binop_helper(al, loc, left, right, ASR::binopType::Add);
         for( std::uint32_t j = 2; j < Case_Stmt->n_test; j++ ) {
-            ASR::expr_t* newExpr = LFortran::ASRUtils::EXPR(ASR::make_Compare_t(al, loc, a_test, ASR::cmpopType::Eq, Case_Stmt->m_test[j], LFortran::ASRUtils::expr_type(a_test), nullptr, nullptr));
-            test_expr = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, loc, test_expr, ASR::binopType::Add, newExpr, LFortran::ASRUtils::expr_type(newExpr), nullptr, nullptr));
+            ASR::expr_t* newExpr = PassUtils::create_compare_helper(al, loc, a_test, Case_Stmt->m_test[j], ASR::cmpopType::Eq);
+            test_expr = PassUtils::create_binop_helper(al, loc, test_expr, newExpr, ASR::binopType::Add);
         }
     }
     return test_expr;
@@ -71,13 +71,13 @@ inline ASR::expr_t* gen_test_expr_CaseStmt(Allocator& al, const Location& loc, A
 inline ASR::expr_t* gen_test_expr_CaseStmt_Range(Allocator& al, const Location& loc, ASR::CaseStmt_Range_t* Case_Stmt, ASR::expr_t* a_test) {
     ASR::expr_t* test_expr = nullptr;
     if( Case_Stmt->m_start != nullptr && Case_Stmt->m_end == nullptr ) {
-        test_expr = LFortran::ASRUtils::EXPR(ASR::make_Compare_t(al, loc, Case_Stmt->m_start, ASR::cmpopType::LtE, a_test, LFortran::ASRUtils::expr_type(a_test), nullptr, nullptr));
+        test_expr = PassUtils::create_compare_helper(al, loc, Case_Stmt->m_start, a_test, ASR::cmpopType::LtE);
     } else if( Case_Stmt->m_start == nullptr && Case_Stmt->m_end != nullptr ) {
-        test_expr = LFortran::ASRUtils::EXPR(ASR::make_Compare_t(al, loc, a_test, ASR::cmpopType::LtE,  Case_Stmt->m_end, LFortran::ASRUtils::expr_type(a_test), nullptr, nullptr));
+        test_expr = PassUtils::create_compare_helper(al, loc, a_test, Case_Stmt->m_end, ASR::cmpopType::LtE);
     } else if( Case_Stmt->m_start != nullptr && Case_Stmt->m_end != nullptr ) {
-        ASR::expr_t* left = LFortran::ASRUtils::EXPR(ASR::make_Compare_t(al, loc, Case_Stmt->m_start, ASR::cmpopType::LtE, a_test, LFortran::ASRUtils::expr_type(a_test), nullptr, nullptr));
-        ASR::expr_t* right = LFortran::ASRUtils::EXPR(ASR::make_Compare_t(al, loc, a_test, ASR::cmpopType::LtE,  Case_Stmt->m_end, LFortran::ASRUtils::expr_type(a_test), nullptr, nullptr));
-        test_expr = LFortran::ASRUtils::EXPR(ASR::make_BinOp_t(al, loc, left, ASR::binopType::Mul, right, LFortran::ASRUtils::expr_type(left), nullptr, nullptr));
+        ASR::expr_t* left = PassUtils::create_compare_helper(al, loc, Case_Stmt->m_start, a_test, ASR::cmpopType::LtE);
+        ASR::expr_t* right = PassUtils::create_compare_helper(al, loc, a_test, Case_Stmt->m_end, ASR::cmpopType::LtE);
+        test_expr = PassUtils::create_binop_helper(al, loc, left, right, ASR::binopType::Mul);
     }
     return test_expr;
 }
@@ -90,13 +90,13 @@ void case_to_if(Allocator& al, const ASR::Select_t& x, ASR::expr_t* a_test, Vec<
         case ASR::case_stmtType::CaseStmt: {
             ASR::CaseStmt_t* Case_Stmt = (ASR::CaseStmt_t*)(&(case_body->base));
             ASR::expr_t* test_expr = gen_test_expr_CaseStmt(al, x.base.base.loc, Case_Stmt, a_test);
-            last_if_else = LFortran::ASRUtils::STMT(ASR::make_If_t(al, x.base.base.loc, test_expr, Case_Stmt->m_body, Case_Stmt->n_body, x.m_default, x.n_default));
+            last_if_else = ASRUtils::STMT(ASR::make_If_t(al, x.base.base.loc, test_expr, Case_Stmt->m_body, Case_Stmt->n_body, x.m_default, x.n_default));
             break;
         }
         case ASR::case_stmtType::CaseStmt_Range: {
             ASR::CaseStmt_Range_t* Case_Stmt = (ASR::CaseStmt_Range_t*)(&(case_body->base));
             ASR::expr_t* test_expr = gen_test_expr_CaseStmt_Range(al, x.base.base.loc, Case_Stmt, a_test);
-            last_if_else = LFortran::ASRUtils::STMT(ASR::make_If_t(al, x.base.base.loc, test_expr, Case_Stmt->m_body, Case_Stmt->n_body, x.m_default, x.n_default));
+            last_if_else = ASRUtils::STMT(ASR::make_If_t(al, x.base.base.loc, test_expr, Case_Stmt->m_body, Case_Stmt->n_body, x.m_default, x.n_default));
             break;
         }
     }
@@ -125,7 +125,7 @@ void case_to_if(Allocator& al, const ASR::Select_t& x, ASR::expr_t* a_test, Vec<
         Vec<ASR::stmt_t*> if_body_vec;
         if_body_vec.reserve(al, 1);
         if_body_vec.push_back(al, last_if_else);
-        last_if_else = LFortran::ASRUtils::STMT(ASR::make_If_t(al, x.base.base.loc, test_expr, m_body, n_body, if_body_vec.p, if_body_vec.size()));
+        last_if_else = ASRUtils::STMT(ASR::make_If_t(al, x.base.base.loc, test_expr, m_body, n_body, if_body_vec.p, if_body_vec.size()));
     }
     body.reserve(al, 1);
     body.push_back(al, last_if_else);

--- a/src/libasr/pass/sign_from_value.cpp
+++ b/src/libasr/pass/sign_from_value.cpp
@@ -80,13 +80,26 @@ public:
         return arg1;
     }
 
-    void visit_BinOp(const ASR::BinOp_t& x_const) {
+    void visit_IntegerBinOp(const ASR::IntegerBinOp_t& x) {
+        handle_BinOp(x);
+    }
+
+    void visit_RealBinOp(const ASR::RealBinOp_t& x) {
+        handle_BinOp(x);
+    }
+
+    void visit_ComplexBinOp(const ASR::ComplexBinOp_t& x) {
+        handle_BinOp(x);
+    }
+
+    template <typename T>
+    void handle_BinOp(const T& x_const) {
         if( !from_sign_from_value ) {
             return ;
         }
 
         from_sign_from_value = true;
-        ASR::BinOp_t& x = const_cast<ASR::BinOp_t&>(x_const);
+        T& x = const_cast<T&>(x_const);
 
         sign_from_value_var = nullptr;
         visit_expr(*x.m_left);

--- a/src/libasr/pass/unused_functions.cpp
+++ b/src/libasr/pass/unused_functions.cpp
@@ -244,8 +244,9 @@ public:
 
 };
 
-void pass_unused_functions(Allocator &al, ASR::TranslationUnit_t &unit) {
-    if (is_program_present(unit)) {
+void pass_unused_functions(Allocator &al, ASR::TranslationUnit_t &unit,
+        bool always_run) {
+    if (is_program_present(unit) || always_run) {
         for (int i=0; i < 4; i++)
         {
             std::map<uint64_t, std::string> fn_unused;

--- a/src/libasr/pass/unused_functions.h
+++ b/src/libasr/pass/unused_functions.h
@@ -5,7 +5,8 @@
 
 namespace LFortran {
 
-    void pass_unused_functions(Allocator &al, ASR::TranslationUnit_t &unit);
+    void pass_unused_functions(Allocator &al, ASR::TranslationUnit_t &unit,
+        bool always_run);
 
 } // namespace LFortran
 

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -21,6 +21,7 @@ struct CompilerOptions {
     bool c_preprocessor = false;
     std::vector<std::string> c_preprocessor_defines;
     bool prescan = true;
+    bool disable_main = false;
     bool symtab_only = false;
     bool show_stacktrace = false;
     bool use_colors = true;

--- a/src/libasr/wasm_instructions.txt
+++ b/src/libasr/wasm_instructions.txt
@@ -1,9 +1,10 @@
+0x40 ⇒ emtpy_block_type
 0x00 ⇒ unreachable
 0x01 ⇒ nop
 -- 0x02 bt:blocktype (in:instr)* 0x0B ⇒ block bt in* end
 -- 0x03 bt:blocktype (in:instr)* 0x0B ⇒ loop bt in* end
--- 0x04 bt:blocktype (in:instr)* 0x0B ⇒ if bt in* else 𝜖 end
--- 0x05 (in2:instr)* 0x0B ⇒ else bt in*1 else in*2 end
+0x04 ⇒ if
+0x05 ⇒ else
 0x0C u32:labelidx:𝑙 ⇒ br 𝑙
 0x0D u32:labelidx:𝑙 ⇒ br_if 𝑙
 -- 0x0E 𝑙*:vec(labelidx) 𝑙𝑁:labelidx ⇒ br_table 𝑙* 𝑙𝑁


### PR DESCRIPTION
This PR syncs the current `Libasr` of `LFortran` and `LPython`.

Corresponding MR at `LFortran`:  https://gitlab.com/lfortran/lfortran/-/merge_requests/1816

Corresponding PR at `LPython`: https://github.com/lcompilers/lpython/pull/730

**Notes:**
- Reference tests for both `LFortran` and `LPython` updated.
    - For `LPython`, it seems there is change in reference tests of `cpp` backend only.
- At few places in the code (exactly `4` places, I think), there is a comment starting with `Sync:` indicating slight doubt in the respective `code`/`statement`
- For `LPython`: All tests pass.
- For `LFortran`: Few tests (5 failing tests in `tests/tests.toml` and 4 failing tests in `integration_tests/CMakeLists.txt`) are commented out. The comments are marked with `Sync:` (to ease lookup / to mark as failing due to sync).